### PR TITLE
Resizable grouped drawing items

### DIFF
--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -134,7 +134,13 @@ public class SelectionHandler implements Handler {
                                 break;
                             }
                         }
-                    } else if (item != null && item.contains(listener.getStartX(), listener.getStartY())) {
+                    } else if (item instanceof Grouped) {
+                        context.setBehaviour(injector.getInstance(GroupedItemBehaviour.class));
+                        boolean found = context.select(item, i);
+                        if (found) {
+                            break;
+                        }
+                     } else if (item != null && item.contains(listener.getStartX(), listener.getStartY())) {
                         // Rest of Shapes
                         view.setSelected(i);
                         context.setContainment(ContainsType.SHAPE);

--- a/src/main/java/net/perspective/draw/event/behaviours/GroupedItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/GroupedItemBehaviour.java
@@ -23,11 +23,18 @@
  */
 package net.perspective.draw.event.behaviours;
 
+import java.util.List;
 import javafx.scene.Cursor;
 import javax.inject.Inject;
+import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.event.DrawAreaListener;
 import net.perspective.draw.geom.DrawItem;
+import net.perspective.draw.geom.Grouped;
+import net.perspective.draw.util.CanvasPoint;
+import net.perspective.draw.util.R2;
+import net.perspective.draw.util.V2;
 
 /**
  * 
@@ -37,6 +44,7 @@ import net.perspective.draw.geom.DrawItem;
 public class GroupedItemBehaviour implements ItemBehaviours {
 
     @Inject private DrawingArea drawarea;
+    @Inject private CanvasView view;
     @Inject private DrawAreaListener listener;
 
     /** 
@@ -48,8 +56,49 @@ public class GroupedItemBehaviour implements ItemBehaviours {
 
     @Override
     public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
-        // Not implemented
-        return false;
+        boolean found = false;
+        int quad;
+
+        List<CanvasPoint[]> vertices = ((Grouped) item).getVertices();
+        CanvasPoint centre = item.rotationCentre();
+        for (CanvasPoint[] vertex : vertices) {
+            if (context.getRegion(vertex[0]).contains(listener.getStartX(), listener.getStartY())) {
+                quad = R2.quadrant(vertex[1], centre);
+                switch (quad) {
+                    case 0 -> {
+                        view.setSelected(index);
+                        context.setContainment(ContainsType.TR);
+                        found = true;
+                    }
+                    case 1 -> {
+                        view.setSelected(index);
+                        context.setContainment(ContainsType.TL);
+                        found = true;
+                    }
+                    case 2 -> {
+                        view.setSelected(index);
+                        context.setContainment(ContainsType.BL);
+                        found = true;
+                    }
+                    case 3 -> {
+                        view.setSelected(index);
+                        context.setContainment(ContainsType.BR);
+                        found = true;
+                    }
+                    default -> {
+                    }
+                }
+            }
+        }
+        if (found) {
+            context.setSgndArea(((Grouped) item).sgnd_area());
+        }
+        if (!found && item.contains(listener.getStartX(), listener.getStartY())) {
+            view.setSelected(index);
+            context.setContainment(ContainsType.SHAPE);
+            found = true;
+        }
+        return found;
     }
 
     @Override
@@ -59,23 +108,207 @@ public class GroupedItemBehaviour implements ItemBehaviours {
 
     @Override
     public void hoverItem(BehaviourContext context, DrawItem item) {
-        if (item.contains(listener.getTempX(), listener.getTempY())) {
-            drawarea.getScene().setCursor(Cursor.OPEN_HAND);
-        } else {
-            drawarea.getScene().setCursor(Cursor.DEFAULT);
+        List<CanvasPoint[]> vertices = ((Grouped) item).getVertices();
+        CanvasPoint centre = item.rotationCentre();
+        boolean found = this.switchVertices(context, vertices, centre);
+        if (!found) {
+            if (item.contains(listener.getTempX(), listener.getTempY())) {
+                drawarea.getScene().setCursor(Cursor.OPEN_HAND);
+            } else {
+                drawarea.getScene().setCursor(Cursor.DEFAULT);
+            }
         }
     }
 
     @Override
     public void alterItem(BehaviourContext context, DrawItem item, double xinc, double yinc) {
         drawarea.getScene().getRoot().setCursor(Cursor.CLOSED_HAND);
-        if (listener.isSnapEnabled()) {
-            xinc = context.getOmega().getX() - item.getStart().getX();
-            yinc = context.getOmega().getY() - item.getStart().getY();
-            drawarea.moveToWithIncrements(item, xinc, yinc);
+
+        ContainsType contains;
+        CanvasPoint s, e, end;
+        double sgn;
+
+        if (context.getContainment().equals(ContainsType.SHAPE)) {
+            if (listener.isSnapEnabled()) {
+                xinc = context.getOmega().getX() - item.getStart().getX();
+                yinc = context.getOmega().getY() - item.getStart().getY();
+                drawarea.moveToWithIncrements(item, xinc, yinc);
+            } else {
+                item.moveTo(xinc, yinc);
+            }
         } else {
-            item.moveTo(xinc, yinc);
+
+            CanvasPoint st = item.getStart();
+            CanvasPoint en = item.getEnd();
+            CanvasPoint es = new CanvasPoint(en.x - st.x, en.y - st.y);
+            double scale = ((Grouped) item).getScale();
+
+            if (!context.getContainment().equals(ContainsType.SHAPE)
+                    && !context.getContainment().equals(ContainsType.NONE)) {
+                if (context.getContains().equals(ContainsType.NONE)) {
+                    context.setContains(R2.permute(context.getContainment(), R2.quadrant(st, item.rotationCentre())));
+                }
+                contains = context.getContains();
+            } else {
+                contains = context.getContainment();
+            }
+
+            /**
+             * Adjust for quadrant of TL vertex
+             */
+            if (context.getQuad() == -1) {
+                int quad = R2.quadrant(item.getTop()[1], item.rotationCentre());
+                context.setQuad(quad);
+            }
+
+            // reproduce unrotated actual coordinates
+            s = new CanvasPoint(st.x, st.y);
+            e = new CanvasPoint(st.x + (en.x - st.x) * scale, st.y + (en.y - st.y) * scale);
+
+            // retrieve increment correctors
+            int[] flip = R2.flip(context.getQuad());
+            int cos_t = flip[0];
+            int sin_t = flip[1];
+            int csx_t = flip[2];
+            int csy_t = flip[3];
+
+            // correct increment for angle of rotation
+            @SuppressWarnings("deprecation")
+            double t = item.getAngle() + (item.isVertical() ? -Math.PI / 2 : 0);
+            double delta = V2.norm_angle(4 * t + 2 * Math.PI) / 2;
+            CanvasPoint inc = V2.rot(xinc, yinc, t - delta);
+
+            // correct increment for negative scale factor
+            if (context.getSgndArea() >= 0) {
+                inc.x = -inc.x;
+                inc.y = -inc.y;
+            }
+
+            // correct increment for picture aspect ratio
+            double cni = Math.max(Math.abs(inc.x), Math.abs(inc.y));
+            double sgnx = Math.signum(inc.x);
+            double sgny = Math.signum(inc.y);
+
+            inc.x = sgnx * cni;
+            inc.y = sgny * cni * (en.y - st.y) / (en.x - st.x);
+
+            boolean sgnD = sgnx == sgny;
+
+            switch (contains) {
+                case TL:
+                    if ((context.getQuad() == 0 || context.getQuad() == 2)) {
+                        s.translate((cos_t - sin_t) * inc.x, (cos_t + sin_t) * (sgnD ? -sgnx * Math.abs(inc.y) : inc.y));
+                        e.translate((-cos_t + sin_t + csy_t) * inc.x, (-cos_t - sin_t + csx_t) * inc.y);
+                    } else {
+                        s.translate((cos_t - sin_t) * (sgnD ? inc.x : -sgnx * Math.abs(inc.x)), (cos_t + sin_t) * inc.y);
+                        e.translate((-cos_t + sin_t + csy_t) * inc.x, (-cos_t - sin_t + csx_t) * inc.y);
+                    }
+                    item.moveTo(s.x - st.x, s.y - st.y);
+                    sgn = Math.signum(e.x - s.x);
+                    end = new CanvasPoint(e.x - s.x, e.y - s.y);
+                    ((Grouped) item).setScale(V2.L2(end) * sgn / V2.L2(es));
+                    break;
+                case BL:
+                    if ((context.getQuad() == 0 || context.getQuad() == 2)) {
+                        s.translate((cos_t + sin_t) * (sgnD ? inc.x : -sgnx * Math.abs(inc.x)), (-cos_t + sin_t + csy_t) * inc.y);
+                        e.translate((-cos_t - sin_t + csx_t) * inc.x, (cos_t - sin_t) * inc.y);
+                    } else {
+                        s.translate((cos_t + sin_t) * (sgnD ? -sgnx * Math.abs(inc.x) : inc.x), (-cos_t + sin_t + csy_t) * inc.y);
+                        e.translate((-cos_t - sin_t + csx_t) * inc.x, (cos_t - sin_t) * (sgnD ? sgnx * Math.abs(inc.y) : inc.y));
+                    }
+                    item.moveTo(s.x - st.x, s.y - st.y);
+                    sgn = Math.signum(e.y - s.y);
+                    end = new CanvasPoint(e.x - s.x, e.y - s.y);
+                    ((Grouped) item).setScale(V2.L2(end) * sgn / V2.L2(es));
+                    break;
+                case BR:
+                    if ((context.getQuad() == 0 || context.getQuad() == 2)) {
+                        s.translate((-cos_t + sin_t + csy_t) * inc.x, (-cos_t - sin_t + csx_t) * inc.y);
+                        e.translate((cos_t - sin_t) * inc.x, (cos_t + sin_t) * (sgnD ? -sgnx * Math.abs(inc.y) : inc.y));
+                    } else {
+                        s.translate((-cos_t + sin_t + csy_t) * inc.x, (-cos_t - sin_t + csx_t) * inc.y);
+                        e.translate((cos_t - sin_t) * (sgnD ? inc.x : -sgnx * Math.abs(inc.x)), (cos_t + sin_t) * inc.y);
+                    }
+                    item.moveTo(s.x - st.x, s.y - st.y);
+                    sgn = Math.signum(e.x - s.x);
+                    end = new CanvasPoint(e.x - s.x, e.y - s.y);
+                    ((Grouped) item).setScale(V2.L2(end) * sgn / V2.L2(es));
+                    break;
+                case TR:
+                    if ((context.getQuad() == 0 || context.getQuad() == 2)) {
+                        s.translate((-cos_t - sin_t + csx_t) * inc.x, (cos_t - sin_t) * (sgnD ? inc.y : sgnx * Math.abs(inc.y)));
+                        e.translate((cos_t + sin_t) * inc.x, (-cos_t + sin_t + csy_t) * inc.y);
+                    } else {
+                        s.translate((-cos_t - sin_t + csx_t) * inc.x, (cos_t - sin_t) * (sgnD ? sgnx * Math.abs(inc.y) : inc.y));
+                        e.translate((cos_t + sin_t) * (sgnD ? -sgnx * Math.abs(inc.x) : inc.x), (-cos_t + sin_t + csy_t) * inc.y);
+                    }
+                    item.moveTo(s.x - st.x, s.y - st.y);
+                    sgn = Math.signum(e.y - s.y);
+                    end = new CanvasPoint(e.x - s.x, e.y - s.y);
+                    ((Grouped) item).setScale(V2.L2(end) * sgn / V2.L2(es));
+                    break;
+                case SHAPE:
+                    if (listener.isSnapEnabled()) {
+                        xinc = context.getOmega().getX() - item.getStart().getX();
+                        yinc = context.getOmega().getY() - item.getStart().getY();
+                        drawarea.moveToWithIncrements(item, xinc, yinc);
+                    } else {
+                        item.moveTo(xinc, yinc);
+                    }
+                    break;
+                case NONE:
+                default:
+                    break;
+            }
         }
+    }
+
+    private boolean switchVertices(BehaviourContext context, List<CanvasPoint[]> vertices, CanvasPoint centre) {
+        boolean found = false;
+        int octa;
+        for (CanvasPoint[] vertex : vertices) {
+            if (context.getRegion(vertex[0]).contains(listener.getTempX(), listener.getTempY())) {
+                octa = R2.octant(vertex[1], centre);
+                switch (octa) {
+                    case 0 -> {
+                        drawarea.getScene().setCursor(Cursor.E_RESIZE);
+                        found = true;
+                    }
+                    case 1 -> {
+                        drawarea.getScene().setCursor(Cursor.NE_RESIZE);
+                        found = true;
+                    }
+                    case 2 -> {
+                        drawarea.getScene().setCursor(Cursor.N_RESIZE);
+                        found = true;
+                    }
+                    case 3 -> {
+                        drawarea.getScene().setCursor(Cursor.NW_RESIZE);
+                        found = true;
+                    }
+                    case 4 -> {
+                        drawarea.getScene().setCursor(Cursor.W_RESIZE);
+                        found = true;
+                    }
+                    case 5 -> {
+                        drawarea.getScene().setCursor(Cursor.SW_RESIZE);
+                        found = true;
+                    }
+                    case 6 -> {
+                        drawarea.getScene().setCursor(Cursor.S_RESIZE);
+                        found = true;
+                    }
+                    case 7 -> {
+                        drawarea.getScene().setCursor(Cursor.SE_RESIZE);
+                        found = true;
+                    }
+                }
+            }
+            if (found) {
+                break;
+            }
+        }
+        return found;
     }
 
 }

--- a/src/main/java/net/perspective/draw/workers/ReadInFunnel.java
+++ b/src/main/java/net/perspective/draw/workers/ReadInFunnel.java
@@ -193,6 +193,7 @@ public class ReadInFunnel extends Task<Object> {
             }
             item.setAngle(drawing.getAngle());
             ((Grouped) item).setTransparency(grouped.getTransparency());
+            ((Grouped) item).setScale(grouped.getScale());            
             drawing = item;
         }
 


### PR DESCRIPTION
Grouped is a type that holds a collection of DrawItems. This PR provides the methods to allow this by adding a scale property to Grouped and implements the drawing listener behaviours to resize grouped items. The code is adapted from work done on my Swing version of Gesticulate.