### PR TITLE
Figure has VECTOR type with path persistence

### DIFF
--- a/src/main/java/net/perspective/draw/geom/FigurePathFactory.java
+++ b/src/main/java/net/perspective/draw/geom/FigurePathFactory.java
@@ -144,6 +144,11 @@ public class FigurePathFactory implements PathFactory {
                 path = Bezier.fitBezierPath(cPoints, 0.75).toGeneralPath();
                 path.closePath();
             }
+            case VECTOR -> {
+                if (figure.getPath() != null) {
+                    path = figure.getPath();
+                }
+            }
             default -> {
                 return null;
             }

--- a/src/main/java/net/perspective/draw/serialise/Path2DPersistenceDelegate.java
+++ b/src/main/java/net/perspective/draw/serialise/Path2DPersistenceDelegate.java
@@ -1,0 +1,97 @@
+/**
+ * Path2DPersistenceDelegate.java
+ *
+ * Created on 8 Aug 2025 10:20:23
+ *
+ */
+
+/**
+ * Copyright (c) 2025 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw.serialise;
+
+import java.awt.geom.Path2D;
+import java.beans.*;
+import java.util.Arrays;
+
+/**
+ *
+ * @author ctipper
+ */
+
+public class Path2DPersistenceDelegate extends DefaultPersistenceDelegate {
+
+    @Override
+    protected boolean mutatesTo(Object oldInstance, Object newInstance) {
+        if (!(oldInstance instanceof Path2D.Double) || !(newInstance instanceof Path2D.Double)) {
+            return false;
+        }
+
+        Path2D.Double oldPath = (Path2D.Double) oldInstance;
+        Path2D.Double newPath = (Path2D.Double) newInstance;
+
+        // Quick checks first
+        if (oldPath.getWindingRule() != newPath.getWindingRule()) {
+            return false;
+        }
+
+        // Compare path data (you might want to cache this)
+        double[][] oldData = getPathData(oldPath);
+        double[][] newData = getPathData(newPath);
+
+        return Arrays.deepEquals(oldData, newData);
+    }
+
+    @Override
+    protected Expression instantiate(final Object oldInstance, final Encoder out) {
+        Path2D.Double path = (Path2D.Double) oldInstance;
+        return new Expression(path, PathFactory.class, "createPath", new Object[] {
+            path.getWindingRule(),
+            new PathData(getPathData(path)) // Wrap in PathData
+        });
+    }
+
+    // Helper method to extract path data
+    private double[][] getPathData(Path2D.Double path) {
+        java.util.List<double[]> pathData = new java.util.ArrayList<>();
+        double[] coords = new double[6];
+        java.awt.geom.PathIterator iterator = path.getPathIterator(null);
+
+        while (!iterator.isDone()) {
+            int segmentType = iterator.currentSegment(coords);
+
+            switch (segmentType) {
+                case java.awt.geom.PathIterator.SEG_MOVETO ->
+                    pathData.add(new double[] { 0, coords[0], coords[1] });
+                case java.awt.geom.PathIterator.SEG_LINETO ->
+                    pathData.add(new double[] { 1, coords[0], coords[1] });
+                case java.awt.geom.PathIterator.SEG_QUADTO ->
+                    pathData.add(new double[] { 2, coords[0], coords[1], coords[2], coords[3] });
+                case java.awt.geom.PathIterator.SEG_CUBICTO ->
+                    pathData.add(new double[] { 3, coords[0], coords[1], coords[2], coords[3], coords[4], coords[5] });
+                case java.awt.geom.PathIterator.SEG_CLOSE ->
+                    pathData.add(new double[] { 4 });
+            }
+            iterator.next();
+        }
+
+        return pathData.toArray(double[][]::new);
+    }
+
+    public Path2DPersistenceDelegate() {
+    }
+
+}

--- a/src/main/java/net/perspective/draw/serialise/PathData.java
+++ b/src/main/java/net/perspective/draw/serialise/PathData.java
@@ -1,8 +1,8 @@
-/*
- * FigureType.java
- * 
- * Created on Oct 19, 2013 6:05:23 PM
- * 
+/**
+ * PathData.java
+ *
+ * Created on 8 Aug 2025 19:08:26
+ *
  */
 
 /**
@@ -21,13 +21,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package net.perspective.draw.geom;
+package net.perspective.draw.serialise;
 
 /**
- * 
+ *
  * @author ctipper
  */
 
-public enum FigureType {
-    LINE, CIRCLE, SQUARE, TRIANGLE, HEXAGON, PENTAGRAM, SKETCH, POLYGON, VECTOR, NONE
+public class PathData {
+
+    private double[][] segments;
+
+    public PathData() {
+    }
+
+    public PathData(double[][] segments) {
+        this.segments = segments;
+    }
+
+    public double[][] getSegments() {
+        return segments;
+    }
+
+    public void setSegments(double[][] segments) {
+        this.segments = segments;
+    }
+
 }

--- a/src/main/java/net/perspective/draw/serialise/PathFactory.java
+++ b/src/main/java/net/perspective/draw/serialise/PathFactory.java
@@ -1,0 +1,55 @@
+/**
+ * PathFactory.java
+ *
+ * Created on 8 Aug 2025 18:46:01
+ *
+ */
+
+/**
+ * Copyright (c) 2025 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw.serialise;
+
+import java.awt.geom.Path2D;
+
+/**
+ *
+ * @author ctipper
+ */
+
+public class PathFactory {
+
+    public static Path2D.Double createPath(int windingRule, PathData pathData) {
+        Path2D.Double path = new Path2D.Double(windingRule);
+        for (double[] segment : pathData.getSegments()) {
+            int type = (int) segment[0];
+            switch (type) {
+                case 0 ->
+                    path.moveTo(segment[1], segment[2]);
+                case 1 ->
+                    path.lineTo(segment[1], segment[2]);
+                case 2 ->
+                    path.quadTo(segment[1], segment[2], segment[3], segment[4]);
+                case 3 ->
+                    path.curveTo(segment[1], segment[2], segment[3], segment[4], segment[5], segment[6]);
+                case 4 ->
+                    path.closePath();
+            }
+        }
+        return path;
+    }
+
+}

--- a/src/main/java/net/perspective/draw/workers/WriteOutStreamer.java
+++ b/src/main/java/net/perspective/draw/workers/WriteOutStreamer.java
@@ -24,19 +24,18 @@
 package net.perspective.draw.workers;
 
 import java.awt.image.BufferedImage;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javax.imageio.ImageIO;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.embed.swing.SwingFXUtils;
-import javax.imageio.ImageIO;
-import javax.inject.Inject;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.ImageItem;
@@ -48,10 +47,9 @@ import net.perspective.draw.serialise.BasicStrokePersistenceDelegate;
 import net.perspective.draw.serialise.FigurePersistenceDelegate;
 import net.perspective.draw.serialise.FigureTypePersistenceDelegate;
 import net.perspective.draw.serialise.InstantPersistenceDelegate;
+import net.perspective.draw.serialise.Path2DPersistenceDelegate;
 import net.perspective.draw.serialise.TextPersistenceDelegate;
 import net.perspective.draw.util.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * 
@@ -179,6 +177,8 @@ public class WriteOutStreamer extends Task<Object> {
                 new FigurePersistenceDelegate());
             encoder.setPersistenceDelegate(net.perspective.draw.geom.Text.class,
                 new TextPersistenceDelegate());
+            encoder.setPersistenceDelegate(java.awt.geom.Path2D.Double.class,
+                new Path2DPersistenceDelegate());
             encoder.setExceptionListener((Exception ex) -> {
                 logger.warn(ex.getMessage());
             });


### PR DESCRIPTION
This PR adds a new Figure VECTOR type with persistence for Java2D paths. No UI at the moment but it is anticipated that vector image import from other sources will be supported.