### PR TITLE
Add Polish localisation and macOS language-bundle support

### DIFF
--- a/src/main/java/net/perspective/draw/Gesticulate.java
+++ b/src/main/java/net/perspective/draw/Gesticulate.java
@@ -174,12 +174,18 @@ public class Gesticulate extends Application {
         pane.setContent(drawareaProvider.get().getScene());
         this.setOnResize(pane);
 
-        // open canvas from file if requested
+        // open canvas from file if requested - only accept args that are real,
+        // existing files, so stray launcher switches (e.g. -AppleLanguages) are ignored
         final Parameters parameters = getParameters();
         final List<String> args = parameters.getRaw();
         final List<File> files = new ArrayList<>();
         for (String arg : args) {
-            files.add(new File(arg));
+            final File file = new File(arg);
+            if (file.isFile()) {
+                files.add(file);
+            } else {
+                logger.debug("ignoring non-file argument: {}", arg);
+            }
         }
         if (!files.isEmpty()) {
             share.loadCanvas(files);

--- a/src/main/java/net/perspective/draw/ShareUtils.java
+++ b/src/main/java/net/perspective/draw/ShareUtils.java
@@ -44,9 +44,11 @@ import net.perspective.draw.workers.PNGWorker;
 import net.perspective.draw.workers.ReadInFunnel;
 import net.perspective.draw.workers.SVGWorker;
 import net.perspective.draw.workers.WriteOutStreamer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * 
+ *
  * @author ctipper
  */
 
@@ -67,6 +69,8 @@ public class ShareUtils {
     private File canvasfile;
     private final double margin;
     public final ExecutorService executor;
+
+    private static final Logger logger = LoggerFactory.getLogger(ShareUtils.class.getName());
 
     @Inject
     public ShareUtils(Provider<Gesticulate> applicationProvider, CanvasView view, ApplicationController controller) {
@@ -207,12 +211,19 @@ public class ShareUtils {
      * @param files a list of files
      */
     public void loadCanvas(List<File> files) {
-        File file = files.get(0);
-        if (FileUtils.getExtension(file).equals("gst")) {
-            view.clearView();
-            readCanvas(file);
-        } else {
-            readPictures(files);
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+        try {
+            File file = files.get(0);
+            if (FileUtils.getExtension(file).equals("gst")) {
+                view.clearView();
+                readCanvas(file);
+            } else {
+                readPictures(files);
+            }
+        } catch (Exception ex) {
+            logger.error("failed to load canvas from {}", files, ex);
         }
     }
 

--- a/src/main/java/net/perspective/draw/util/Messages.java
+++ b/src/main/java/net/perspective/draw/util/Messages.java
@@ -39,8 +39,9 @@ import org.slf4j.LoggerFactory;
  * translations may contain non-ASCII characters directly.</p>
  *
  * <p>The locale is taken from the environment as the sole authority: German,
- * French, Spanish and Brazilian/European Portuguese load their bundle, every
- * other locale resolves to the en-GB base. The same {@link ResourceBundle} is
+ * French, Spanish, Polish and Brazilian/European Portuguese load their
+ * bundle, every other locale resolves to the en-GB base. The same
+ * {@link ResourceBundle} is
  * fed to the {@code FXMLLoader} (for {@code %key} references in the FXML) and
  * used here for programmatic strings (status messages, the about box).</p>
  *
@@ -67,7 +68,7 @@ public final class Messages {
 
     /**
      * Resolve the UI locale from the environment over the supported set.
-     * German, French and Spanish map to the language; Portuguese is split
+     * German, French, Spanish and Polish map to the language; Portuguese is split
      * into Brazilian ({@code pt_BR}) and European ({@code pt_PT}, the default
      * for any non-Brazilian Portuguese); anything else falls back to en-GB.
      *
@@ -76,7 +77,7 @@ public final class Messages {
     private static Locale selectLocale() {
         Locale def = Locale.getDefault();
         return switch (def.getLanguage()) {
-            case "de", "fr", "es" -> Locale.of(def.getLanguage());
+            case "de", "fr", "es", "pl" -> Locale.of(def.getLanguage());
             case "pt" -> "BR".equals(def.getCountry()) ? Locale.of("pt", "BR") : Locale.of("pt", "PT");
             default -> Locale.UK;
         };

--- a/src/main/resources/net/perspective/draw/resources/ui_pl.properties
+++ b/src/main/resources/net/perspective/draw/resources/ui_pl.properties
@@ -1,0 +1,72 @@
+# Gesticulate FX UI strings - Polish (pl)
+#
+# Loaded by net.perspective.draw.util.Messages for the Polish locale.
+# Read as UTF-8 (Java 9+), so diacritics may be written directly.
+# Keys without a Polish entry fall back to the base ui.properties (en-GB).
+
+# --- Toolbar tooltips ---
+tooltip.options=Opcje
+tooltip.strokeWidth=Grubość linii
+tooltip.strokeStyle=Styl linii
+tooltip.fillColor=Kolor wypełnienia
+tooltip.strokeColor=Kolor linii
+tooltip.copyFormat=Kopiuj formatowanie
+tooltip.isometric=Rysuj izometrycznie
+tooltip.outline=Rysuj kontur
+tooltip.font=Czcionka
+tooltip.fontSize=Rozmiar czcionki
+tooltip.bold=Pogrubienie
+tooltip.italic=Kursywa
+tooltip.underline=Podkreślenie
+tooltip.snapshot=Zrzut na pulpit
+tooltip.iconLibrary=Pokaż bibliotekę ikon
+tooltip.new=Nowy
+tooltip.open=Otwórz
+tooltip.save=Zapisz
+tooltip.select=Zaznacz
+tooltip.rotate=Obróć
+tooltip.enableGuides=Włącz prowadnice
+tooltip.showGrid=Pokaż siatkę
+tooltip.background=Tło...
+
+# --- Shape names (toolbar tooltips) ---
+shape.line=Linia
+shape.horizontal=Poziomo
+shape.circle=Koło
+shape.square=Kwadrat
+shape.triangle=Trójkąt
+shape.hexagon=Sześciokąt
+shape.pentagram=Pentagram
+shape.sketch=Szkic
+shape.text=Tekst
+
+# --- Toolbar labels ---
+label.fill=Wypełnij
+label.color=Kolor
+label.align=Wyrównaj
+label.grid=Siatka
+
+# --- Menu items ---
+menu.file.saveAs=Zapisz jako...
+menu.file.exportPdf=Eksportuj PDF...
+menu.file.exportSvg=Eksportuj SVG...
+menu.file.exportImage=Eksportuj obraz...
+menu.file.quit=Zakończ
+menu.insert.image=Wstaw obrazy...
+menu.insert.mapping=Wstaw mapę...
+menu.app.about=O programie...
+
+# --- Status messages ---
+status.dropper=Wybrano narzędzie zakraplacz
+status.dropperOff=Zakraplacz wyłączony
+status.exportedPng=Wyeksportowano do PNG
+status.exportedSvg=Wyeksportowano do SVG
+status.exportedPdf=Wyeksportowano do PDF
+status.savedDocument=Zapisano dokument
+status.openedDocument=Otwarto dokument
+status.readPictures=Wczytano obrazy
+status.textTooLarge=Treść tekstu zbyt duża
+
+# --- About box ---
+about.tagline=Proste rysowanie odręczne
+about.rights=Wszelkie prawa zastrzeżone.

--- a/src/site/ant/build.xml
+++ b/src/site/ant/build.xml
@@ -199,6 +199,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <arg value="${build.dir}/${app.name}.app/Contents/Info.plist"/>
       </exec>
 
+      <!-- allow per-locale InfoPlist.strings to take effect -->
+      <exec executable="/usr/libexec/PlistBuddy" if:set="onmacos" failonerror="false">
+          <arg value="-c"/>
+          <arg value="Add :CFBundleAllowMixedLocalizations bool true"/>
+          <arg value="${build.dir}/${app.name}.app/Contents/Info.plist"/>
+      </exec>
+
+      <!-- Create localized resource folders with a minimal InfoPlist.strings -->
+
+      <macrodef name="lproj">
+          <attribute name="lang"/>
+          <sequential>
+              <mkdir dir="${build.dir}/${app.name}.app/Contents/Resources/@{lang}.lproj"/>
+              <echo file="${build.dir}/${app.name}.app/Contents/Resources/@{lang}.lproj/InfoPlist.strings" encoding="UTF-8">CFBundleDisplayName = "${app.name}";
+CFBundleName = "${app.name}";
+</echo>
+          </sequential>
+      </macrodef>
+
+      <lproj if:set="onmacos" lang="en"/>
+      <lproj if:set="onmacos" lang="de"/>
+      <lproj if:set="onmacos" lang="pt"/>
+      <lproj if:set="onmacos" lang="pt_BR"/>
+      <lproj if:set="onmacos" lang="es"/>
+      <lproj if:set="onmacos" lang="pl"/>
+      <lproj if:set="onmacos" lang="fr"/>
+
       <exec executable="${jpackage.windows.path}/bin/jpackage.exe" if:set="onwindows" failonerror="false" newenvironment="true">
          <env key="JAVA_HOME" value="${jpackage.windows.path}"/>
          <arg value="--type"/>


### PR DESCRIPTION
## Summary

Adds Polish (pl) as a supported UI language, wires up macOS app-bundle
localisation so the system offers the app's languages, and hardens
command-line/file-open handling against invalid arguments.

## Changes

### Polish localisation
- Add `ui_pl.properties` resource bundle (full UI string set).
- Recognise `pl` in `Messages.selectLocale()` alongside de/fr/es, with
  Portuguese still split into pt_BR / pt_PT and everything else falling
  back to en-GB.

### macOS bundle localisation
- Create per-locale `.lproj` folders (en, de, pt, pt_BR, es, pl, fr) under
  `Contents/Resources`, each with a minimal `InfoPlist.strings`.
- Set `CFBundleAllowMixedLocalizations` in `Info.plist` so macOS lists the
  app in the per-app language picker (System Settings › Language & Region).

### File-handling hardening
- Filter launch arguments to existing files only, so stray launcher
  switches (e.g. `-AppleLanguages` passed via `open --args`) no longer get
  treated as files to open and crash startup.
- Centralise error handling in `ShareUtils.loadCanvas` with a try/catch and
  null/empty guard, covering both the CLI argument path and the macOS
  open-file handler — a missing/corrupt file is now logged, not fatal.

## Testing
- `mvn compile` — clean build.
- Locale verified via `defaults write … AppleLanguages` / per-app picker
  (note: do not use `open --args -AppleLanguages`, which forwards the args
  to the app).
