### PR TITLE
Paste images and SVG from the clipboard and file manager

### DIFF
--- a/src/main/java/net/perspective/draw/ApplicationController.java
+++ b/src/main/java/net/perspective/draw/ApplicationController.java
@@ -23,11 +23,8 @@
  */
 package net.perspective.draw;
 
-import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.ResourceBundle;
 import java.util.concurrent.CompletableFuture;
@@ -35,14 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import org.apache.batik.anim.dom.SVGDOMImplementation;
-import org.apache.batik.transcoder.SVGAbstractTranscoder;
-import org.apache.batik.transcoder.TranscoderException;
-import org.apache.batik.transcoder.TranscoderInput;
-import org.apache.batik.transcoder.TranscoderOutput;
-import org.apache.batik.transcoder.TranscodingHints;
-import org.apache.batik.transcoder.image.ImageTranscoder;
-import org.apache.batik.util.SVGConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javafx.animation.FadeTransition;
@@ -104,6 +93,7 @@ import net.perspective.draw.enums.KeyHandlerType;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.util.FileUtils;
 import net.perspective.draw.util.Messages;
+import net.perspective.draw.util.SVGRead;
 
 /**
  * 
@@ -118,6 +108,7 @@ public class ApplicationController implements Initializable {
     private Gesticulate application;
     @Inject ShareUtils share;
     @Inject MapController mapper;
+    @Inject SVGRead svgRead;
     @Inject Provider<Picture> pictureProvider;
     private BooleanProperty snapshotEnabled;
     private BooleanProperty progressBarVisible;
@@ -152,9 +143,10 @@ public class ApplicationController implements Initializable {
     private final String SVG_SKETCH = "M9.683105 12.160538C9.387039 11.739883,8.870743 11.533356,8.366211 11.633789C7.209183 11.864105,6.822739 13.242813,7.049316 14.530975C7.212357 15.457993,7.598648 16.360352,8.366211 16.901367C11.324356 18.986465,15.644501 15.517441,14.160538 10.975342C13.918884 10.235748,13.520340 9.555481,12.975342 9.000000C9.410904 5.367126,3.067444 7.514481,1.781738 12.950684C0.468903 18.501633,5.099258 23.668060,11.000000 23.485840C17.038956 23.299332,21.461807 17.802231,21.008408 11.633789C20.603149 6.120422,16.446732 1.645233,11.000000 0.571884C7.478043 -0.122177,3.828094 0.742279,0.991592 2.942276";
     private final String SVG_POLYGON = "M18.730026 5.361984L13.638016 0.269974C4.441025 0.341461,-2.007233 9.368988,0.907990 18.092010C1.734192 20.564240,3.469177 22.750504,6.000000 23.184021C7.693268 23.474060,11.145432 21.827255,13.638016 20.638016C15.358093 19.817337,18.366989 18.381744,18.730026 18.092010C22.815308 14.831955,22.815308 8.622040,18.730026 5.361984Z";
 
-    private static final Logger logger = LoggerFactory.getLogger(ApplicationController.class.getName());
+    /** Raster width for SVG icons, supersampled to stay crisp when scaled. */
+    private static final int ICON_WIDTH = 128;
 
-    private static final boolean MAC_OS_X = System.getProperty("os.name").toLowerCase().startsWith("mac os x");
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationController.class.getName());
 
     public void setApplication(Gesticulate application) {
         this.application = application;
@@ -1282,7 +1274,7 @@ public class ApplicationController implements Initializable {
         final String filename = ((Button) ev.getSource()).getId().substring(3);
         CompletableFuture.runAsync(() -> {
             try {
-                Image image = SwingFXUtils.toFXImage(rasterizeSVGResource(filename, toRGBCode(drawareaProvider.get().getFillColor())), null);
+                Image image = SwingFXUtils.toFXImage(svgRead.rasterizeResource(filename, toRGBCode(drawareaProvider.get().getFillColor()), ICON_WIDTH), null);
                 Picture picture = pictureProvider.get();
                 picture.setStart(shift, shift);
                 ImageItem item = new ImageItem(image);
@@ -1290,7 +1282,7 @@ public class ApplicationController implements Initializable {
                 int index = viewProvider.get().setImageItem(item);
                 double width = (double) image.getWidth();
                 double height = (double) image.getHeight();
-                double scale = 64d / height;
+                double scale = 48d / height;
                 logger.trace("Image relative scale: {}", scale);
                 picture.setImage(index, width, height);
                 picture.setScale(scale);
@@ -1317,8 +1309,9 @@ public class ApplicationController implements Initializable {
             Button[] button = new Button[4];
             for (int j=0; j < 4; j++) {
                 try {
-                    image[j] = new ImageView(SwingFXUtils.toFXImage(rasterizeSVGResource(svgStrings.get(i * 4 + j), themeAccentColor.getValue()), null));
+                    image[j] = new ImageView(SwingFXUtils.toFXImage(svgRead.rasterizeResource(svgStrings.get(i * 4 + j), themeAccentColor.getValue(), ICON_WIDTH), null));
                     image[j].setFitWidth(35.0);
+                    image[j].setFitHeight(35.0);
                     image[j].setPreserveRatio(true);
                     button[j] = new Button();
                     button[j].setId("ia_" + svgStrings.get(i * 4 + j));
@@ -1463,60 +1456,11 @@ public class ApplicationController implements Initializable {
         "plane-departure.svg", "plane.svg", "recycle.svg", "restroom.svg", "road-barrier.svg", "sailboat.svg", "school.svg", "ship.svg",
         "square-phone.svg", "tractor.svg", "train-subway.svg", "trees.svg", "truck-field.svg", "utensils.svg", "water.svg", "wheelchair.svg");
 
-    private BufferedImage rasterizeSVGResource(String filename, String fillColor) throws IOException {
-
-        final BufferedImage[] imagePointer = new BufferedImage[1];
-
-        // Rendering hints can't be set programatically, so
-        // we override defaults with a temporary stylesheet.
-        // These defaults emphasize quality and precision, and
-        // are more similar to the defaults of other SVG viewers.
-        // SVG documents can still override these defaults.
-        String css = "svg {"
-                + "shape-rendering: geometricPrecision;"
-                + "text-rendering:  geometricPrecision;"
-                + "color-rendering: optimizeQuality;"
-                + "image-rendering: optimizeQuality;"
-                + "fill: " + fillColor + ";"
-                + "}";
-        Path cssFile = Files.createTempFile(Files.createTempDirectory("temp-dir"), "batik-default-override-", ".css");
-        FileUtils.writeStringToFile(cssFile.toFile(), css);
-        TranscodingHints transcoderHints = new TranscodingHints();
-        transcoderHints.put(ImageTranscoder.KEY_XML_PARSER_VALIDATING, Boolean.FALSE);
-        transcoderHints.put(ImageTranscoder.KEY_DOM_IMPLEMENTATION,
-                SVGDOMImplementation.getDOMImplementation());
-        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,
-                SVGConstants.SVG_NAMESPACE_URI);
-        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT, "svg");
-        transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssFile.toUri().toString());
-        transcoderHints.put(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, Boolean.TRUE);
-
-        try (InputStream file = getClass().getResourceAsStream("/svg/" + filename)) {
-            TranscoderInput input = new TranscoderInput(file);
-
-            ImageTranscoder t = new ImageTranscoder() {
-
-                @Override
-                public BufferedImage createImage(int width, int height) {
-                    return new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-                }
-
-                @Override
-                public void writeImage(BufferedImage image, TranscoderOutput out) throws TranscoderException {
-                    imagePointer[0] = image;
-                }
-            };
-            t.setTranscodingHints(transcoderHints);
-            t.transcode(input, null);
-        } catch (TranscoderException ex) {
-            logger.error("Couldn't convert {}", filename);
-        } catch (IOException ex) {
-            logger.error("Couldn't read SVG image {}", filename);
-        }
-        return imagePointer[0];
-    }
-
-    /** Creates a new instance of <code>ApplicationController</code> */
+    /** 
+     * Creates a new instance of <code>ApplicationController</code>
+     * @param drawareaProvider
+     * @param viewProvider 
+     */
     @Inject
     public ApplicationController(Provider<DrawingArea> drawareaProvider, Provider<CanvasView> viewProvider) {
         this.drawareaProvider = drawareaProvider;

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -65,7 +65,6 @@ public class CanvasTransferHandler {
     String mimeType = DataFlavor.javaSerializedObjectMimeType
         + ";class=net.perspective.draw.geom.DrawItem";
     DataFlavor drawItemFlavor;
-    private Flavor flavor = Flavor.NONE;
     private double shift;
     private double pageWidth;      // canvas width pixels
     private double pageHeight;     // canvas height pixels
@@ -93,7 +92,7 @@ public class CanvasTransferHandler {
      * the canvas.
      * <p>
      * The supported payload is resolved from the transfer by
-     * {@link #hasDrawItemFlavor} and dispatched to the matching handler:
+     * {@link #resolveFlavor} and dispatched to the matching handler:
      * a serialized {@link DrawItem}, raw image data, a list of image files, or
      * SVG markup. Each successful import nudges the paste offset so repeated
      * pastes do not stack exactly on top of one another.
@@ -104,17 +103,17 @@ public class CanvasTransferHandler {
      *         transfer held nothing importable or a transfer error occurred
      */
     public boolean importData(Transferable t) {
-        if (!hasDrawItemFlavor(t)) {
+        Payload payload = resolveFlavor(t);
+        if (payload == null) {
             logger.trace("ImportData");
             return false;
         }
         try {
-            boolean imported = switch (flavor) {
+            boolean imported = switch (payload.flavor()) {
                 case DRAWITEM -> importDrawItem(t);
                 case IMAGEITEM -> importImageItem(t);
                 case FILEITEM -> importFileItem(t);
-                case SVGITEM -> importSvgItem(t);
-                case NONE -> false;
+                case SVGITEM -> importSvgItem(payload.svg());
             };
             if (imported) {
                 shift = shift + 20.0;
@@ -196,11 +195,10 @@ public class CanvasTransferHandler {
     }
 
     /**
-     * Paste SVG markup from the clipboard by rasterizing it in memory and placing
-     * it on the canvas.
+     * Paste SVG markup (already captured during {@link #resolveFlavor}) by
+     * rasterizing it in memory and placing it on the canvas.
      */
-    private boolean importSvgItem(Transferable t) throws UnsupportedFlavorException, IOException {
-        String svg = (String) t.getTransferData(DataFlavor.stringFlavor);
+    private boolean importSvgItem(String svg) throws IOException {
         BufferedImage buffered = svgRead.rasterize(svg);
         if (buffered == null) {
             logger.debug("importData: could not rasterize pasted SVG");
@@ -267,8 +265,8 @@ public class CanvasTransferHandler {
     }
 
     /**
-     * Resolve which supported payload a transfer offers and record it in
-     * {@link #flavor} for {@link #importData} to dispatch on.
+     * Resolve which supported payload a transfer offers, for {@link #importData}
+     * to dispatch on.
      * <p>
      * A single transfer may advertise several flavors at once, so they are
      * matched in priority order regardless of their order in the array: a native
@@ -277,57 +275,57 @@ public class CanvasTransferHandler {
      * so they load via {@code ImageLoadWorker} (svg-aware, threaded, with a
      * progress indicator) rather than being decoded eagerly; SVG markup is the
      * lowest priority and only matches when the string actually looks like SVG.
+     * The SVG text is read once here and carried on the returned {@link Payload}
+     * so the import does not re-read the clipboard.
      *
      * @param t the transfer whose flavors (and, for SVG, content) are inspected
-     * @return {@code true} if a supported flavor was found (and {@link #flavor}
-     *         set accordingly), {@code false} otherwise (with {@link #flavor}
-     *         reset to {@link Flavor#NONE})
+     * @return the resolved {@link Payload}, or {@code null} if nothing importable was found
      */
-    protected boolean hasDrawItemFlavor(Transferable t) {
+    private Payload resolveFlavor(Transferable t) {
         DataFlavor[] flavors = t.getTransferDataFlavors();
         for (DataFlavor f : flavors) {
             if (drawItemFlavor.equals(f)) {
                 logger.debug(mimeType);
-                flavor = Flavor.DRAWITEM;
-                return true;
+                return new Payload(Flavor.DRAWITEM, null);
             }
         }
         for (DataFlavor f : flavors) {
             if (DataFlavor.javaFileListFlavor.equals(f)) {
                 logger.debug("application/x-java-file-list;class=java.util.List");
-                flavor = Flavor.FILEITEM;
-                return true;
+                return new Payload(Flavor.FILEITEM, null);
             }
         }
         for (DataFlavor f : flavors) {
             if (DataFlavor.imageFlavor.equals(f)) {
                 logger.debug("image/x-java-image;class=java.awt.Image");
-                flavor = Flavor.IMAGEITEM;
-                return true;
+                return new Payload(Flavor.IMAGEITEM, null);
             }
         }
         for (DataFlavor f : flavors) {
             if (DataFlavor.stringFlavor.equals(f)) {
                 try {
-                    if (isSvgMarkup((String) t.getTransferData(DataFlavor.stringFlavor))) {
+                    String text = (String) t.getTransferData(DataFlavor.stringFlavor);
+                    if (isSvgMarkup(text)) {
                         logger.debug("image/svg+xml;class=java.lang.String");
-                        flavor = Flavor.SVGITEM;
-                        return true;
+                        return new Payload(Flavor.SVGITEM, text);
                     }
                 } catch (UnsupportedFlavorException | IOException e) {
-                    logger.warn("hasDrawItemFlavor: could not read clipboard text");
+                    logger.warn("resolveFlavor: could not read clipboard text");
                 }
                 break;
             }
         }
 
-        flavor = Flavor.NONE;
-        return false;
+        return null;
     }
 
-    /** Supported clipboard payloads, resolved by {@link #hasDrawItemFlavor}. */
+    /** A resolved clipboard payload: its kind, plus the captured SVG markup for {@link Flavor#SVGITEM}. */
+    private record Payload(Flavor flavor, String svg) {
+    }
+
+    /** Supported clipboard payloads, resolved by {@link #resolveFlavor}. */
     private enum Flavor {
-        DRAWITEM, IMAGEITEM, FILEITEM, SVGITEM, NONE
+        DRAWITEM, IMAGEITEM, FILEITEM, SVGITEM
     }
 
     private DrawItem checkDrawings(DrawItem drawing) {

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -218,8 +218,7 @@ public class CanvasTransferHandler {
         if (text == null) {
             return false;
         }
-        String head = text.stripLeading();
-        head = head.substring(0, Math.min(head.length(), 512)).toLowerCase();
+        String head = text.stripLeading().toLowerCase();
         return head.startsWith("<svg")
             || head.startsWith("<!doctype svg")
             || (head.startsWith("<?xml") && head.contains("<svg"));

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -30,6 +30,8 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -42,6 +44,7 @@ import net.perspective.draw.geom.DrawItem;
 import net.perspective.draw.geom.Grouped;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.geom.StreetMap;
+import net.perspective.draw.util.FileUtils;
 
 /**
  * 
@@ -54,12 +57,13 @@ public class CanvasTransferHandler {
     private final Provider<DrawingArea> drawareaProvider;
     private final Provider<CanvasView> viewProvider;
     @Inject MapController mapper;
+    @Inject Provider<ShareUtils> shareProvider;
     @Inject Provider<Picture> pictureProvider;
     @Inject Provider<StreetMap> streetMapProvider;
     String mimeType = DataFlavor.javaSerializedObjectMimeType
         + ";class=net.perspective.draw.geom.DrawItem";
     DataFlavor drawItemFlavor;
-    String dataflavor = "";
+    private Flavor flavor = Flavor.NONE;
     private double shift;
     private double pageWidth;      // canvas width pixels
     private double pageHeight;     // canvas height pixels
@@ -82,45 +86,110 @@ public class CanvasTransferHandler {
         shift = 10.0;
     }
 
+    /**
+     * Import the contents of a transfer (clipboard paste or drag-and-drop) onto
+     * the canvas.
+     * <p>
+     * The supported payload is resolved from the transfer's flavors by
+     * {@link #hasDrawItemFlavor} and dispatched to the matching handler:
+     * a serialized {@link DrawItem}, raw image data, or a list of image files.
+     * Each successful import nudges the paste offset so repeated pastes do not
+     * stack exactly on top of one another.
+     *
+     * @param t the transfer to import; its available {@link DataFlavor}s
+     *          determine how it is handled
+     * @return {@code true} if a supported item was imported, {@code false} if the
+     *         transfer held nothing importable or a transfer error occurred
+     */
     public boolean importData(Transferable t) {
-        if (hasDrawItemFlavor(t.getTransferDataFlavors())) {
-            try {
-                if (dataflavor.equals("drawitem")) {
-                    DrawItem item = (DrawItem) t.getTransferData(drawItemFlavor);
-                    // add item to Canvas
-                    item.moveTo(shift, shift);
-                    item = checkDrawings(item);
-                    viewProvider.get().appendItemToCanvas(item);
-                } else if (dataflavor.equals("imageitem")) {
-                    java.awt.Image img = (java.awt.Image) t.getTransferData(DataFlavor.imageFlavor);
-                    Image image = SwingFXUtils.toFXImage(toBufferedImage(img), null);
-                    Picture picture = pictureProvider.get();
-                    picture.moveTo(shift, shift);
-                    ImageItem item = new ImageItem(image);
-                    item.setFormat("PNG");
-                    int index = viewProvider.get().setImageItem(item);
-                    double width = (double) image.getWidth();
-                    double height = (double) image.getHeight();
-                    double scale = getScale(width, height);
-                    logger.debug("Image relative scale: {}", scale);
-                    picture.setImage(index, width, height);
-                    picture.setScale(scale);
-                    viewProvider.get().setNewItem(picture);
-                    viewProvider.get().resetNewItem();
-                }
+        if (!hasDrawItemFlavor(t.getTransferDataFlavors())) {
+            logger.trace("ImportData");
+            return false;
+        }
+        try {
+            boolean imported = switch (flavor) {
+                case DRAWITEM -> importDrawItem(t);
+                case IMAGEITEM -> importImageItem(t);
+                case FILEITEM -> importFileItem(t);
+                case NONE -> false;
+            };
+            if (imported) {
                 shift = shift + 20.0;
                 logger.debug("Item added to canvas");
-                return true;
-            } catch (UnsupportedFlavorException e) {
-                logger.warn("importData: unsupported data flavor");
-            } catch (IOException e) {
-                logger.warn("importData: I/O exception");
             }
+            return imported;
+        } catch (UnsupportedFlavorException e) {
+            logger.warn("importData: unsupported data flavor");
+        } catch (IOException e) {
+            logger.warn("importData: I/O exception");
         }
-        logger.trace("ImportData");
         return false;
     }
 
+    /**
+     * Paste a serialized {@link DrawItem} onto the canvas.
+     */
+    private boolean importDrawItem(Transferable t) throws UnsupportedFlavorException, IOException {
+        DrawItem item = (DrawItem) t.getTransferData(drawItemFlavor);
+        // add item to Canvas
+        item.moveTo(shift, shift);
+        item = checkDrawings(item);
+        viewProvider.get().appendItemToCanvas(item);
+        return true;
+    }
+
+    /**
+     * Paste raw image data (e.g. copied from another application) onto the canvas.
+     */
+    private boolean importImageItem(Transferable t) throws UnsupportedFlavorException, IOException {
+        java.awt.Image img = (java.awt.Image) t.getTransferData(DataFlavor.imageFlavor);
+        Image image = SwingFXUtils.toFXImage(toBufferedImage(img), null);
+        Picture picture = pictureProvider.get();
+        picture.moveTo(shift, shift);
+        ImageItem item = new ImageItem(image);
+        item.setFormat("PNG");
+        int index = viewProvider.get().setImageItem(item);
+        double width = (double) image.getWidth();
+        double height = (double) image.getHeight();
+        double scale = getScale(width, height);
+        logger.debug("Image relative scale: {}", scale);
+        picture.setImage(index, width, height);
+        picture.setScale(scale);
+        viewProvider.get().setNewItem(picture);
+        viewProvider.get().resetNewItem();
+        return true;
+    }
+
+    /**
+     * Paste image files dropped/copied from the file manager (jpg, jpeg, png,
+     * gif, svg). Unsupported entries are ignored; returns {@code false} when the
+     * selection holds no supported image files.
+     */
+    private boolean importFileItem(Transferable t) throws UnsupportedFlavorException, IOException {
+        @SuppressWarnings("unchecked")
+        List<File> files = (List<File>) t.getTransferData(DataFlavor.javaFileListFlavor);
+        List<File> imageFiles = new ArrayList<>();
+        for (File file : files) {
+            switch (FileUtils.getExtension(file.getName()).toLowerCase()) {
+                case "jpg", "jpeg", "png", "gif", "svg" -> imageFiles.add(file);
+            }
+        }
+        if (imageFiles.isEmpty()) {
+            logger.debug("importData: no supported image files in selection");
+            return false;
+        }
+        // ImageLoadWorker handles threading and the progress indicator
+        shareProvider.get().readPictures(imageFiles);
+        return true;
+    }
+
+    /**
+     * Wrap the currently selected drawing in a {@link Transferable} for export
+     * (copy or cut).
+     *
+     * @return a transferable for the selected item, or {@code null} if nothing
+     *         is selected
+     */
     protected Transferable createTransferable() {
         int selected = viewProvider.get().getSelected();
         if (selected == -1) {
@@ -131,6 +200,16 @@ public class CanvasTransferHandler {
         return new DrawItemTransferable(data);
     }
 
+    /**
+     * Finish an export started by {@link #createTransferable}, after the data
+     * has been handed to the clipboard.
+     * <p>
+     * On {@link #MOVE} the source item is removed from the canvas and the paste
+     * offset is reset; on {@link #COPY} the item is left in place.
+     *
+     * @param data   the transferable that was exported
+     * @param action the completed action, either {@link #COPY} or {@link #MOVE}
+     */
     protected void exportDone(Transferable data, int action) {
         if (action == MOVE) {
             viewProvider.get().deleteSelectedItem();
@@ -143,20 +222,52 @@ public class CanvasTransferHandler {
         logger.trace("ExportDone");
     }
 
+    /**
+     * Resolve which supported payload a transfer offers and record it in
+     * {@link #flavor} for {@link #importData} to dispatch on.
+     * <p>
+     * A single transfer may advertise several flavors at once, so they are
+     * matched in priority order regardless of their order in the array: a native
+     * {@link DrawItem} first, then a file list, then raw image data. Image files
+     * are preferred over raw image data so they load via {@code ImageLoadWorker}
+     * (svg-aware, threaded, with a progress indicator) rather than being decoded
+     * eagerly.
+     *
+     * @param flavors the flavors advertised by the transfer
+     * @return {@code true} if a supported flavor was found (and {@link #flavor}
+     *         set accordingly), {@code false} otherwise (with {@link #flavor}
+     *         reset to {@link Flavor#NONE})
+     */
     protected boolean hasDrawItemFlavor(DataFlavor[] flavors) {
         for (DataFlavor f : flavors) {
             if (drawItemFlavor.equals(f)) {
                 logger.debug(mimeType);
-                dataflavor = "drawitem";
+                flavor = Flavor.DRAWITEM;
                 return true;
-            } else if (DataFlavor.imageFlavor.equals(f)) {
+            }
+        }
+        for (DataFlavor f : flavors) {
+            if (DataFlavor.javaFileListFlavor.equals(f)) {
+                logger.debug("application/x-java-file-list;class=java.util.List");
+                flavor = Flavor.FILEITEM;
+                return true;
+            }
+        }
+        for (DataFlavor f : flavors) {
+            if (DataFlavor.imageFlavor.equals(f)) {
                 logger.debug("image/x-java-image;class=java.awt.Image");
-                dataflavor = "imageitem";
+                flavor = Flavor.IMAGEITEM;
                 return true;
             }
         }
 
+        flavor = Flavor.NONE;
         return false;
+    }
+
+    /** Supported clipboard payloads, resolved by {@link #hasDrawItemFlavor}. */
+    private enum Flavor {
+        DRAWITEM, IMAGEITEM, FILEITEM, NONE
     }
 
     private DrawItem checkDrawings(DrawItem drawing) {

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -45,7 +45,6 @@ import net.perspective.draw.geom.Grouped;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.geom.StreetMap;
 import net.perspective.draw.util.FileUtils;
-import net.perspective.draw.util.SVGRead;
 
 /**
  * 
@@ -58,7 +57,6 @@ public class CanvasTransferHandler {
     private final Provider<DrawingArea> drawareaProvider;
     private final Provider<CanvasView> viewProvider;
     @Inject MapController mapper;
-    @Inject SVGRead svgRead;
     @Inject Provider<ShareUtils> shareProvider;
     @Inject Provider<Picture> pictureProvider;
     @Inject Provider<StreetMap> streetMapProvider;
@@ -200,16 +198,12 @@ public class CanvasTransferHandler {
     }
 
     /**
-     * Paste SVG markup (already captured during {@link #resolveFlavor}) by
-     * rasterizing it in memory and placing it on the canvas.
+     * Paste SVG markup (already captured during {@link #resolveFlavor}). SVG
+     * transcoding can be slow, so it is rasterized in the background by
+     * {@link ShareUtils#readSVGMarkup(String)} with the shared progress indicator.
      */
-    private boolean importSvgItem(String svg) throws IOException {
-        BufferedImage buffered = svgRead.rasterize(svg);
-        if (buffered == null) {
-            logger.debug("importData: could not rasterize pasted SVG");
-            return false;
-        }
-        placeImage(SwingFXUtils.toFXImage(buffered, null), "svg");
+    private boolean importSvgItem(String svg) {
+        shareProvider.get().readSVGMarkup(svg);
         return true;
     }
 

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -64,8 +64,6 @@ public class CanvasTransferHandler {
         + ";class=net.perspective.draw.geom.DrawItem";
     DataFlavor drawItemFlavor;
     private double shift;
-    private double pageWidth;      // canvas width pixels
-    private double pageHeight;     // canvas height pixels
 
     public static int COPY = 1;
     public static int MOVE = 2;
@@ -161,7 +159,7 @@ public class CanvasTransferHandler {
         int index = viewProvider.get().setImageItem(item);
         double width = (double) image.getWidth();
         double height = (double) image.getHeight();
-        double scale = getScale(width, height);
+        double scale = drawareaProvider.get().fitScale(width, height);
         logger.debug("Image relative scale: {}", scale);
         picture.setImage(index, width, height);
         picture.setScale(scale);
@@ -360,41 +358,6 @@ public class CanvasTransferHandler {
         }
 
         return drawing;
-    }
-
-    /**
-     * Get a representative scale for images larger than page size
-     * 
-     * 1. ImageWidth &gt; pageWidth resize to 80% pageWidth
-     * 2. ImageHeight &gt; pageHeight resize to 80% pageHeight
-     * 3. if imageSize &lt; pageSize do nothing
-     * 
-     * @param width
-     * @param height
-     * @return 
-     */
-    private double getScale(double width, double height) {
-        pageWidth = drawareaProvider.get().getScene().getWidth();
-        pageHeight = drawareaProvider.get().getScene().getHeight();
-        if ((width <= pageWidth) && (height <= pageHeight)) {
-            return 1d;
-        }
-        if ((width <= pageWidth) && (height > pageHeight)) {
-            return 0.8 * pageHeight / height;
-        }
-        if ((width > pageWidth) && (height <= pageHeight)) {
-            return 0.8 * pageWidth / width;
-        }
-        if ((width > pageWidth) && (height > pageHeight)) {
-            double ratio_w = pageWidth / width;
-            double ratio_h = pageHeight / height;
-            if (ratio_w <= ratio_h) {
-                return 0.8 * pageWidth / width;
-            } else {
-                return 0.8 * pageHeight / height;
-            }
-        }
-        return 1d;
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -30,7 +30,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -46,6 +45,7 @@ import net.perspective.draw.geom.Grouped;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.geom.StreetMap;
 import net.perspective.draw.util.FileUtils;
+import net.perspective.draw.util.SVGRead;
 
 /**
  * 
@@ -58,6 +58,7 @@ public class CanvasTransferHandler {
     private final Provider<DrawingArea> drawareaProvider;
     private final Provider<CanvasView> viewProvider;
     @Inject MapController mapper;
+    @Inject SVGRead svgRead;
     @Inject Provider<ShareUtils> shareProvider;
     @Inject Provider<Picture> pictureProvider;
     @Inject Provider<StreetMap> streetMapProvider;
@@ -145,11 +146,21 @@ public class CanvasTransferHandler {
      */
     private boolean importImageItem(Transferable t) throws UnsupportedFlavorException, IOException {
         java.awt.Image img = (java.awt.Image) t.getTransferData(DataFlavor.imageFlavor);
-        Image image = SwingFXUtils.toFXImage(toBufferedImage(img), null);
+        placeImage(SwingFXUtils.toFXImage(toBufferedImage(img), null), "PNG");
+        return true;
+    }
+
+    /**
+     * Place a loaded image onto the canvas as a scaled {@link Picture}.
+     *
+     * @param image the image to add
+     * @param format the source format recorded on the {@link ImageItem}
+     */
+    private void placeImage(Image image, String format) {
         Picture picture = pictureProvider.get();
         picture.moveTo(shift, shift);
         ImageItem item = new ImageItem(image);
-        item.setFormat("PNG");
+        item.setFormat(format);
         int index = viewProvider.get().setImageItem(item);
         double width = (double) image.getWidth();
         double height = (double) image.getHeight();
@@ -159,7 +170,6 @@ public class CanvasTransferHandler {
         picture.setScale(scale);
         viewProvider.get().setNewItem(picture);
         viewProvider.get().resetNewItem();
-        return true;
     }
 
     /**
@@ -186,14 +196,17 @@ public class CanvasTransferHandler {
     }
 
     /**
-     * Paste SVG markup from the clipboard by spooling it to a temporary
-     * {@code .svg} file and loading it like any other image file.
+     * Paste SVG markup from the clipboard by rasterizing it in memory and placing
+     * it on the canvas.
      */
     private boolean importSvgItem(Transferable t) throws UnsupportedFlavorException, IOException {
-        String text = (String) t.getTransferData(DataFlavor.stringFlavor);
-        File file = writeSvgToTempFile(text);
-        // ImageLoadWorker handles threading and the progress indicator
-        shareProvider.get().readPictures(List.of(file));
+        String svg = (String) t.getTransferData(DataFlavor.stringFlavor);
+        BufferedImage buffered = svgRead.rasterize(svg);
+        if (buffered == null) {
+            logger.debug("importData: could not rasterize pasted SVG");
+            return false;
+        }
+        placeImage(SwingFXUtils.toFXImage(buffered, null), "svg");
         return true;
     }
 
@@ -212,22 +225,6 @@ public class CanvasTransferHandler {
         return head.startsWith("<svg")
             || head.startsWith("<!doctype svg")
             || (head.startsWith("<?xml") && head.contains("<svg"));
-    }
-
-    /**
-     * Write pasted SVG markup to a temporary file so it can be rasterized by
-     * {@link net.perspective.draw.util.SVGRead#rasterize(File)} via
-     * {@link ShareUtils#readPictures(List)}.
-     *
-     * @param text the SVG markup
-     * @return a temporary {@code .svg} file holding the markup
-     * @throws IOException if the file cannot be written
-     */
-    private File writeSvgToTempFile(String text) throws IOException {
-        File file = File.createTempFile("clipboard", ".svg");
-        file.deleteOnExit();
-        Files.writeString(file.toPath(), text);
-        return file;
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -187,6 +187,11 @@ public class CanvasTransferHandler {
         }
         if (imageFiles.isEmpty()) {
             logger.debug("importData: no supported image files in selection");
+            // the file list yielded nothing usable; fall back to raw image data
+            // when the transfer also offers it, rather than dropping the paste
+            if (t.isDataFlavorSupported(DataFlavor.imageFlavor)) {
+                return importImageItem(t);
+            }
             return false;
         }
         // ImageLoadWorker handles threading and the progress indicator

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -30,6 +30,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -90,11 +91,11 @@ public class CanvasTransferHandler {
      * Import the contents of a transfer (clipboard paste or drag-and-drop) onto
      * the canvas.
      * <p>
-     * The supported payload is resolved from the transfer's flavors by
+     * The supported payload is resolved from the transfer by
      * {@link #hasDrawItemFlavor} and dispatched to the matching handler:
-     * a serialized {@link DrawItem}, raw image data, or a list of image files.
-     * Each successful import nudges the paste offset so repeated pastes do not
-     * stack exactly on top of one another.
+     * a serialized {@link DrawItem}, raw image data, a list of image files, or
+     * SVG markup. Each successful import nudges the paste offset so repeated
+     * pastes do not stack exactly on top of one another.
      *
      * @param t the transfer to import; its available {@link DataFlavor}s
      *          determine how it is handled
@@ -102,7 +103,7 @@ public class CanvasTransferHandler {
      *         transfer held nothing importable or a transfer error occurred
      */
     public boolean importData(Transferable t) {
-        if (!hasDrawItemFlavor(t.getTransferDataFlavors())) {
+        if (!hasDrawItemFlavor(t)) {
             logger.trace("ImportData");
             return false;
         }
@@ -111,6 +112,7 @@ public class CanvasTransferHandler {
                 case DRAWITEM -> importDrawItem(t);
                 case IMAGEITEM -> importImageItem(t);
                 case FILEITEM -> importFileItem(t);
+                case SVGITEM -> importSvgItem(t);
                 case NONE -> false;
             };
             if (imported) {
@@ -184,6 +186,51 @@ public class CanvasTransferHandler {
     }
 
     /**
+     * Paste SVG markup from the clipboard by spooling it to a temporary
+     * {@code .svg} file and loading it like any other image file.
+     */
+    private boolean importSvgItem(Transferable t) throws UnsupportedFlavorException, IOException {
+        String text = (String) t.getTransferData(DataFlavor.stringFlavor);
+        File file = writeSvgToTempFile(text);
+        // ImageLoadWorker handles threading and the progress indicator
+        shareProvider.get().readPictures(List.of(file));
+        return true;
+    }
+
+    /**
+     * Determine whether pasted text is SVG markup.
+     *
+     * @param text the clipboard string
+     * @return {@code true} if the text looks like an SVG document
+     */
+    private boolean isSvgMarkup(String text) {
+        if (text == null) {
+            return false;
+        }
+        String head = text.stripLeading();
+        head = head.substring(0, Math.min(head.length(), 512)).toLowerCase();
+        return head.startsWith("<svg")
+            || head.startsWith("<!doctype svg")
+            || (head.startsWith("<?xml") && head.contains("<svg"));
+    }
+
+    /**
+     * Write pasted SVG markup to a temporary file so it can be rasterized by
+     * {@link net.perspective.draw.util.SVGRead#rasterize(File)} via
+     * {@link ShareUtils#readPictures(List)}.
+     *
+     * @param text the SVG markup
+     * @return a temporary {@code .svg} file holding the markup
+     * @throws IOException if the file cannot be written
+     */
+    private File writeSvgToTempFile(String text) throws IOException {
+        File file = File.createTempFile("clipboard", ".svg");
+        file.deleteOnExit();
+        Files.writeString(file.toPath(), text);
+        return file;
+    }
+
+    /**
      * Wrap the currently selected drawing in a {@link Transferable} for export
      * (copy or cut).
      *
@@ -228,17 +275,19 @@ public class CanvasTransferHandler {
      * <p>
      * A single transfer may advertise several flavors at once, so they are
      * matched in priority order regardless of their order in the array: a native
-     * {@link DrawItem} first, then a file list, then raw image data. Image files
-     * are preferred over raw image data so they load via {@code ImageLoadWorker}
-     * (svg-aware, threaded, with a progress indicator) rather than being decoded
-     * eagerly.
+     * {@link DrawItem} first, then a file list, then raw image data, and finally
+     * SVG markup carried as text. Image files are preferred over raw image data
+     * so they load via {@code ImageLoadWorker} (svg-aware, threaded, with a
+     * progress indicator) rather than being decoded eagerly; SVG markup is the
+     * lowest priority and only matches when the string actually looks like SVG.
      *
-     * @param flavors the flavors advertised by the transfer
+     * @param t the transfer whose flavors (and, for SVG, content) are inspected
      * @return {@code true} if a supported flavor was found (and {@link #flavor}
      *         set accordingly), {@code false} otherwise (with {@link #flavor}
      *         reset to {@link Flavor#NONE})
      */
-    protected boolean hasDrawItemFlavor(DataFlavor[] flavors) {
+    protected boolean hasDrawItemFlavor(Transferable t) {
+        DataFlavor[] flavors = t.getTransferDataFlavors();
         for (DataFlavor f : flavors) {
             if (drawItemFlavor.equals(f)) {
                 logger.debug(mimeType);
@@ -260,6 +309,20 @@ public class CanvasTransferHandler {
                 return true;
             }
         }
+        for (DataFlavor f : flavors) {
+            if (DataFlavor.stringFlavor.equals(f)) {
+                try {
+                    if (isSvgMarkup((String) t.getTransferData(DataFlavor.stringFlavor))) {
+                        logger.debug("image/svg+xml;class=java.lang.String");
+                        flavor = Flavor.SVGITEM;
+                        return true;
+                    }
+                } catch (UnsupportedFlavorException | IOException e) {
+                    logger.warn("hasDrawItemFlavor: could not read clipboard text");
+                }
+                break;
+            }
+        }
 
         flavor = Flavor.NONE;
         return false;
@@ -267,7 +330,7 @@ public class CanvasTransferHandler {
 
     /** Supported clipboard payloads, resolved by {@link #hasDrawItemFlavor}. */
     private enum Flavor {
-        DRAWITEM, IMAGEITEM, FILEITEM, NONE
+        DRAWITEM, IMAGEITEM, FILEITEM, SVGITEM, NONE
     }
 
     private DrawItem checkDrawings(DrawItem drawing) {

--- a/src/main/java/net/perspective/draw/DrawAppComponent.java
+++ b/src/main/java/net/perspective/draw/DrawAppComponent.java
@@ -49,6 +49,7 @@ import net.perspective.draw.geom.Picture;
 import net.perspective.draw.geom.StreetMap;
 import net.perspective.draw.text.Editor;
 import net.perspective.draw.util.G2;
+import net.perspective.draw.util.SVGRead;
 import net.perspective.draw.workers.ImageLoadWorker;
 import net.perspective.draw.workers.PDFWorker;
 import net.perspective.draw.workers.PNGWorker;
@@ -195,6 +196,8 @@ public interface DrawAppComponent {
     PNGWorker providePngWorker();
 
     G2 g2();
+
+    SVGRead svgRead();
 
     Picture picture();
 

--- a/src/main/java/net/perspective/draw/DrawAppModule.java
+++ b/src/main/java/net/perspective/draw/DrawAppModule.java
@@ -52,6 +52,7 @@ import net.perspective.draw.text.Editor;
 import net.perspective.draw.text.RichTextEditor;
 import net.perspective.draw.text.TextEditor;
 import net.perspective.draw.util.G2;
+import net.perspective.draw.util.SVGRead;
 import net.perspective.draw.workers.ImageLoadWorker;
 import net.perspective.draw.workers.PDFWorker;
 import net.perspective.draw.workers.PNGWorker;
@@ -314,6 +315,12 @@ public class DrawAppModule {
     G2 provideG2(Provider<DrawingArea> drawareaProvider, Provider<ApplicationController> controllerProvider,
             Provider<TextController> textControllerProvider) {
         return new G2(drawareaProvider, controllerProvider, textControllerProvider);
+    }
+
+    @Provides
+    @Singleton
+    SVGRead provideSVGRead() {
+        return new SVGRead();
     }
 
     @Provides

--- a/src/main/java/net/perspective/draw/DrawingArea.java
+++ b/src/main/java/net/perspective/draw/DrawingArea.java
@@ -805,6 +805,41 @@ public class DrawingArea {
     }
 
     /**
+     * Get a representative scale for fitting an image within the page.
+     *
+     * 1. ImageWidth &gt; pageWidth resize to 80% pageWidth
+     * 2. ImageHeight &gt; pageHeight resize to 80% pageHeight
+     * 3. if imageSize &lt; pageSize do nothing
+     *
+     * @param width the image width in pixels
+     * @param height the image height in pixels
+     * @return the scale factor
+     */
+    public double fitScale(double width, double height) {
+        double pageWidth = getScene().getWidth();
+        double pageHeight = getScene().getHeight();
+        if ((width <= pageWidth) && (height <= pageHeight)) {
+            return 1d;
+        }
+        if ((width <= pageWidth) && (height > pageHeight)) {
+            return 0.8 * pageHeight / height;
+        }
+        if ((width > pageWidth) && (height <= pageHeight)) {
+            return 0.8 * pageWidth / width;
+        }
+        if ((width > pageWidth) && (height > pageHeight)) {
+            double ratio_w = pageWidth / width;
+            double ratio_h = pageHeight / height;
+            if (ratio_w <= ratio_h) {
+                return 0.8 * pageWidth / width;
+            } else {
+                return 0.8 * pageHeight / height;
+            }
+        }
+        return 1d;
+    }
+
+    /**
      * Set the drawing mode
      *
      * @param type the {@link net.perspective.draw.enums.DrawingType}

--- a/src/main/java/net/perspective/draw/ShareUtils.java
+++ b/src/main/java/net/perspective/draw/ShareUtils.java
@@ -42,6 +42,7 @@ import net.perspective.draw.workers.ImageLoadWorker;
 import net.perspective.draw.workers.PDFWorker;
 import net.perspective.draw.workers.PNGWorker;
 import net.perspective.draw.workers.ReadInFunnel;
+import net.perspective.draw.workers.SVGLoadWorker;
 import net.perspective.draw.workers.SVGWorker;
 import net.perspective.draw.workers.WriteOutStreamer;
 import org.slf4j.Logger;
@@ -59,6 +60,7 @@ public class ShareUtils {
     private final CanvasView view;
     private final ApplicationController controller;
     @Inject Provider<ImageLoadWorker> imageLoadWorkerProvider;
+    @Inject Provider<SVGLoadWorker> svgLoadWorkerProvider;
     @Inject Provider<ReadInFunnel> readInFunnelProvider;
     @Inject Provider<WriteOutStreamer> writeOutStreamerProvider;
     @Inject Provider<PDFWorker> pdfWorkerProvider;
@@ -145,6 +147,8 @@ public class ShareUtils {
 
     /**
      * Load images from list of Files
+     * 
+     * @param files
      */
     public void readPictures(List<File> files) {
         this.setImageFiles(files);
@@ -153,6 +157,24 @@ public class ShareUtils {
             controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
             controller.setProgressIndeterminate();
             executor.submit(imageLoader);
+        }
+        controller.setSelectionMode();
+    }
+
+    /**
+     * Rasterize and load SVG markup (e.g. pasted from the clipboard) in the
+     * background. Transcoding can be slow, so it runs off the FX thread with the
+     * shared progress indicator, like {@link #readPictures(List)}.
+     *
+     * @param markup the SVG document markup
+     */
+    public void readSVGMarkup(String markup) {
+        if (markup != null) {
+            SVGLoadWorker svgLoader = svgLoadWorkerProvider.get();
+            svgLoader.setMarkup(markup);
+            controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
+            controller.setProgressIndeterminate();
+            executor.submit(svgLoader);
         }
         controller.setSelectionMode();
     }

--- a/src/main/java/net/perspective/draw/ShareUtils.java
+++ b/src/main/java/net/perspective/draw/ShareUtils.java
@@ -129,7 +129,7 @@ public class ShareUtils {
         chooser.setInitialDirectory(userDirectory);
         chooser.setTitle("Choose Pictures...");
         chooser.getExtensionFilters().addAll(
-                new FileChooser.ExtensionFilter("Image Files", "*.png", "*.jpg", "*.gif", "*.svg"),
+                new FileChooser.ExtensionFilter("Image Files", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.svg"),
                 new FileChooser.ExtensionFilter("All Documents", "*.*"));
         List<File> result = chooser.showOpenMultipleDialog(applicationProvider.get().getStage());
         if (result == null) {

--- a/src/main/java/net/perspective/draw/util/FileUtils.java
+++ b/src/main/java/net/perspective/draw/util/FileUtils.java
@@ -40,14 +40,6 @@ import org.slf4j.LoggerFactory;
 
 public class FileUtils {
 
-    public final static String jpeg = "jpeg";
-    public final static String jpg = "jpg";
-    public final static String gif = "gif";
-    public final static String tiff = "tiff";
-    public final static String tif = "tif";
-    public final static String png = "png";
-    public final static String svg = "svg";
-
     private static final Logger logger = LoggerFactory.getLogger(FileUtils.class.getName());
 
     private FileUtils() {

--- a/src/main/java/net/perspective/draw/util/SVGRead.java
+++ b/src/main/java/net/perspective/draw/util/SVGRead.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.xml.stream.XMLInputFactory;
@@ -87,6 +88,23 @@ public class SVGRead {
     }
 
     /**
+     * Transcode SVG markup held in memory (e.g. pasted from the clipboard), without spooling
+     * it to a temporary file. Treated as untrusted: external resource resolution is disabled.
+     * <p>
+     * Documents that declare only a {@code viewBox} are sized from it, matching {@link #rasterize(File)}.
+     *
+     * @param svg the SVG document markup
+     * @return a buffered image, or {@code null} if Batik could not transcode the markup
+     * @throws IOException
+     */
+    public BufferedImage rasterize(String svg) throws IOException {
+        float[] box = viewBoxSize(svg);
+        float width = box != null ? box[0] : 0f;
+        float height = box != null ? box[1] : 0f;
+        return rasterize(new TranscoderInput(new StringReader(svg)), null, width, height, "clipboard", false);
+    }
+
+    /**
      * Transcode an SVG document bundled as a classpath resource under {@code /svg/},
      * overriding its fill colour.
      *
@@ -138,6 +156,13 @@ public class SVGRead {
                 + "}";
         Path cssFile = Files.createTempFile(Files.createTempDirectory("temp-dir"), "batik-default-override-", ".css");
         FileUtils.writeStringToFile(cssFile.toFile(), css);
+        // Untrusted input carries no document URI, so Batik's same-origin check would also reject
+        // our own injected stylesheet. Base the document in the stylesheet's directory: our
+        // stylesheet is then same-origin (loads), while the document's external references
+        // (other directories, http://, file:///) remain cross-origin and are refused.
+        if (!allowExternalResources && input.getURI() == null) {
+            input.setURI(cssFile.getParent().resolve("document").toUri().toString());
+        }
         TranscodingHints transcoderHints = new TranscodingHints();
         transcoderHints.put(ImageTranscoder.KEY_XML_PARSER_VALIDATING, Boolean.FALSE);
         transcoderHints.put(ImageTranscoder.KEY_DOM_IMPLEMENTATION,
@@ -189,36 +214,61 @@ public class SVGRead {
      */
     private static float[] viewBoxSize(File svgFile) {
         try (InputStream in = new FileInputStream(svgFile)) {
-            XMLInputFactory factory = XMLInputFactory.newFactory();
-            factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
-            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
-            XMLStreamReader reader = factory.createXMLStreamReader(in);
-            while (reader.hasNext()) {
-                if (reader.next() == XMLStreamConstants.START_ELEMENT) {
-                    // the root element of an SVG document
-                    if (isAbsolute(reader.getAttributeValue(null, "width"))
-                            && isAbsolute(reader.getAttributeValue(null, "height"))) {
-                        return null;
-                    }
-                    String viewBox = reader.getAttributeValue(null, "viewBox");
-                    if (viewBox != null) {
-                        String[] parts = viewBox.trim().split("[\\s,]+");
-                        if (parts.length == 4) {
-                            float w = Float.parseFloat(parts[2]);
-                            float h = Float.parseFloat(parts[3]);
-                            if (w > 0f && h > 0f) {
-                                float scale = Math.max(1f, MIN_VIEWBOX_DIMENSION / Math.max(w, h));
-                                return new float[]{ w * scale, h * scale };
-                            }
-                        }
-                    }
-                    return null;
-                }
-            }
+            return readViewBox(secureXmlFactory().createXMLStreamReader(in), svgFile.getName());
         } catch (XMLStreamException | IOException | IllegalArgumentException ex) {
             // IllegalArgumentException covers an unsupported StAX property and a malformed
             // viewBox number (NumberFormatException); either way we fall back to intrinsic sizing.
             logger.warn("Couldn't read SVG dimensions from {}", svgFile.getName());
+        }
+        return null;
+    }
+
+    /**
+     * As {@link #viewBoxSize(File)}, but reading from in-memory markup.
+     *
+     * @param svg the SVG document markup
+     * @return {@code {width, height}}, or {@code null} to use Batik's intrinsic sizing
+     */
+    private static float[] viewBoxSize(String svg) {
+        try {
+            return readViewBox(secureXmlFactory().createXMLStreamReader(new StringReader(svg)), "clipboard");
+        } catch (XMLStreamException | IllegalArgumentException ex) {
+            logger.warn("Couldn't read SVG dimensions from pasted markup");
+        }
+        return null;
+    }
+
+    /** A StAX factory hardened against DTD and external entity resolution (XXE). */
+    private static XMLInputFactory secureXmlFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        return factory;
+    }
+
+    /** Read the root element's {@code viewBox}, returning a size or {@code null} for intrinsic sizing. */
+    private static float[] readViewBox(XMLStreamReader reader, String name) throws XMLStreamException {
+        while (reader.hasNext()) {
+            if (reader.next() == XMLStreamConstants.START_ELEMENT) {
+                // the root element of an SVG document
+                if (isAbsolute(reader.getAttributeValue(null, "width"))
+                        && isAbsolute(reader.getAttributeValue(null, "height"))) {
+                    return null;
+                }
+                String viewBox = reader.getAttributeValue(null, "viewBox");
+                if (viewBox != null) {
+                    String[] parts = viewBox.trim().split("[\\s,]+");
+                    if (parts.length == 4) {
+                        float w = Float.parseFloat(parts[2]);
+                        float h = Float.parseFloat(parts[3]);
+                        if (w > 0f && h > 0f) {
+                            float scale = Math.max(1f, MIN_VIEWBOX_DIMENSION / Math.max(w, h));
+                            return new float[]{ w * scale, h * scale };
+                        }
+                    }
+                }
+                return null;
+            }
         }
         return null;
     }

--- a/src/main/java/net/perspective/draw/util/SVGRead.java
+++ b/src/main/java/net/perspective/draw/util/SVGRead.java
@@ -197,7 +197,15 @@ public class SVGRead {
         } catch (TranscoderException ex) {
             logger.error("Couldn't convert {}", name);
         } finally {
-            cssFile.toFile().deleteOnExit();
+            // the stylesheet has been read by transcode(); remove it and its dedicated
+            // directory now rather than accumulating temp files for the JVM's lifetime
+            try {
+                Files.deleteIfExists(cssFile);
+                Files.deleteIfExists(cssFile.getParent());
+            } catch (IOException ex) {
+                cssFile.toFile().deleteOnExit();
+                cssFile.getParent().toFile().deleteOnExit();
+            }
         }
 
         return imagePointer[0];
@@ -214,7 +222,7 @@ public class SVGRead {
      */
     private static float[] viewBoxSize(File svgFile) {
         try (InputStream in = new FileInputStream(svgFile)) {
-            return readViewBox(secureXmlFactory().createXMLStreamReader(in), svgFile.getName());
+            return readViewBox(secureXmlFactory().createXMLStreamReader(in));
         } catch (XMLStreamException | IOException | IllegalArgumentException ex) {
             // IllegalArgumentException covers an unsupported StAX property and a malformed
             // viewBox number (NumberFormatException); either way we fall back to intrinsic sizing.
@@ -231,7 +239,7 @@ public class SVGRead {
      */
     private static float[] viewBoxSize(String svg) {
         try {
-            return readViewBox(secureXmlFactory().createXMLStreamReader(new StringReader(svg)), "clipboard");
+            return readViewBox(secureXmlFactory().createXMLStreamReader(new StringReader(svg)));
         } catch (XMLStreamException | IllegalArgumentException ex) {
             logger.warn("Couldn't read SVG dimensions from pasted markup");
         }
@@ -247,7 +255,7 @@ public class SVGRead {
     }
 
     /** Read the root element's {@code viewBox}, returning a size or {@code null} for intrinsic sizing. */
-    private static float[] readViewBox(XMLStreamReader reader, String name) throws XMLStreamException {
+    private static float[] readViewBox(XMLStreamReader reader) throws XMLStreamException {
         while (reader.hasNext()) {
             if (reader.next() == XMLStreamConstants.START_ELEMENT) {
                 // the root element of an SVG document

--- a/src/main/java/net/perspective/draw/util/SVGRead.java
+++ b/src/main/java/net/perspective/draw/util/SVGRead.java
@@ -1,0 +1,225 @@
+/**
+ * SVGRead.java
+ *
+ * Created on Jun 26, 2026
+ *
+ */
+
+/**
+ * Copyright (c) 2026 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw.util;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import org.apache.batik.anim.dom.SVGDOMImplementation;
+import org.apache.batik.transcoder.SVGAbstractTranscoder;
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.TranscodingHints;
+import org.apache.batik.transcoder.image.ImageTranscoder;
+import org.apache.batik.util.SVGConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transcodes SVG documents to {@link BufferedImage}s.
+ *
+ * @author ctipper
+ */
+
+public class SVGRead {
+
+    /** Lower bound for the longest side when sizing from a viewBox, so small documents stay legible. */
+    private static final float MIN_VIEWBOX_DIMENSION = 512f;
+
+    private static final Logger logger = LoggerFactory.getLogger(SVGRead.class.getName());
+
+    public SVGRead() {
+    }
+
+    /**
+     * Transcode an SVG file.
+     * <p>
+     * Documents that declare an explicit {@code width} and {@code height} are rendered at
+     * their intrinsic size. Documents that declare only a {@code viewBox} are sized from it,
+     * preserving aspect ratio &mdash; otherwise Batik falls back to a square default that
+     * distorts the picture's bounds.
+     *
+     * @see <a href="https://stackoverflow.com/a/11436655">How to get a BufferedImage from a SVG?</a>
+     *
+     * @param svgFile the file
+     * @return a buffered image
+     * @throws IOException
+     */
+    public BufferedImage rasterize(File svgFile) throws IOException {
+        float[] box = viewBoxSize(svgFile);
+        float width = box != null ? box[0] : 0f;
+        float height = box != null ? box[1] : 0f;
+        try (InputStream file = new FileInputStream(svgFile)) {
+            return rasterize(new TranscoderInput(file), null, width, height, svgFile.getName());
+        }
+    }
+
+    /**
+     * Transcode an SVG document bundled as a classpath resource under {@code /svg/},
+     * overriding its fill colour.
+     *
+     * @param filename the resource name
+     * @param fillColor the fill colour to apply
+     * @param targetSize the size in pixels of the square box to render into (content aspect
+     *     ratio is preserved, letterboxed)
+     * @return a buffered image
+     * @throws IOException
+     */
+    public BufferedImage rasterizeResource(String filename, String fillColor, int targetSize) throws IOException {
+        try (InputStream file = getClass().getResourceAsStream("/svg/" + filename)) {
+            // A square box suits the icon glyphs: many declare only a viewBox (no width/height),
+            // and Batik would otherwise leave its default height in place, distorting the result.
+            return rasterize(new TranscoderInput(file), fillColor, targetSize, targetSize, filename);
+        }
+    }
+
+    /**
+     * Transcode an SVG document.
+     *
+     * @param input the transcoder input
+     * @param fillColor the fill colour to apply, or {@code null} to leave the document defaults
+     * @param targetWidth the output width in pixels, or {@code 0} to leave Batik's default
+     * @param targetHeight the output height in pixels, or {@code 0} to leave Batik's default
+     * @param name an identifier used for logging
+     * @return a buffered image
+     * @throws IOException
+     */
+    private BufferedImage rasterize(TranscoderInput input, String fillColor, float targetWidth, float targetHeight, String name) throws IOException {
+
+        final BufferedImage[] imagePointer = new BufferedImage[1];
+
+        // Rendering hints can't be set programatically, so
+        // we override defaults with a temporary stylesheet.
+        // These defaults emphasize quality and precision, and
+        // are more similar to the defaults of other SVG viewers.
+        // SVG documents can still override these defaults.
+        String css = "svg {"
+                + "shape-rendering: geometricPrecision;"
+                + "text-rendering:  geometricPrecision;"
+                + "color-rendering: optimizeQuality;"
+                + "image-rendering: optimizeQuality;"
+                + (fillColor != null ? "fill: " + fillColor + ";" : "")
+                + "}";
+        Path cssFile = Files.createTempFile(Files.createTempDirectory("temp-dir"), "batik-default-override-", ".css");
+        FileUtils.writeStringToFile(cssFile.toFile(), css);
+        TranscodingHints transcoderHints = new TranscodingHints();
+        transcoderHints.put(ImageTranscoder.KEY_XML_PARSER_VALIDATING, Boolean.FALSE);
+        transcoderHints.put(ImageTranscoder.KEY_DOM_IMPLEMENTATION,
+                SVGDOMImplementation.getDOMImplementation());
+        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,
+                SVGConstants.SVG_NAMESPACE_URI);
+        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT, "svg");
+        transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssFile.toUri().toString());
+        transcoderHints.put(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, Boolean.TRUE);
+        if (targetWidth > 0f) {
+            transcoderHints.put(SVGAbstractTranscoder.KEY_WIDTH, targetWidth);
+        }
+        if (targetHeight > 0f) {
+            transcoderHints.put(SVGAbstractTranscoder.KEY_HEIGHT, targetHeight);
+        }
+
+        try {
+            ImageTranscoder t = new ImageTranscoder() {
+
+                @Override
+                public BufferedImage createImage(int width, int height) {
+                    return new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+                }
+
+                @Override
+                public void writeImage(BufferedImage image, TranscoderOutput out) throws TranscoderException {
+                    imagePointer[0] = image;
+                }
+            };
+            t.setTranscodingHints(transcoderHints);
+            t.transcode(input, null);
+        } catch (TranscoderException ex) {
+            logger.error("Couldn't convert {}", name);
+        } finally {
+            cssFile.toFile().deleteOnExit();
+        }
+
+        return imagePointer[0];
+    }
+
+    /**
+     * Determine a render size from a document's {@code viewBox}, used only when it declares no
+     * usable {@code width}/{@code height} (in which case Batik defaults to a square, distorting
+     * the aspect ratio). The longest side is raised to {@link #MIN_VIEWBOX_DIMENSION} so small
+     * documents remain legible; aspect ratio is preserved.
+     *
+     * @param svgFile the file
+     * @return {@code {width, height}}, or {@code null} to use Batik's intrinsic sizing
+     */
+    private static float[] viewBoxSize(File svgFile) {
+        try (InputStream in = new FileInputStream(svgFile)) {
+            XMLInputFactory factory = XMLInputFactory.newFactory();
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+            XMLStreamReader reader = factory.createXMLStreamReader(in);
+            while (reader.hasNext()) {
+                if (reader.next() == XMLStreamConstants.START_ELEMENT) {
+                    // the root element of an SVG document
+                    if (isAbsolute(reader.getAttributeValue(null, "width"))
+                            && isAbsolute(reader.getAttributeValue(null, "height"))) {
+                        return null;
+                    }
+                    String viewBox = reader.getAttributeValue(null, "viewBox");
+                    if (viewBox != null) {
+                        String[] parts = viewBox.trim().split("[\\s,]+");
+                        if (parts.length == 4) {
+                            float w = Float.parseFloat(parts[2]);
+                            float h = Float.parseFloat(parts[3]);
+                            if (w > 0f && h > 0f) {
+                                float scale = Math.max(1f, MIN_VIEWBOX_DIMENSION / Math.max(w, h));
+                                return new float[]{ w * scale, h * scale };
+                            }
+                        }
+                    }
+                    return null;
+                }
+            }
+        } catch (XMLStreamException | IOException | IllegalArgumentException ex) {
+            // IllegalArgumentException covers an unsupported StAX property and a malformed
+            // viewBox number (NumberFormatException); either way we fall back to intrinsic sizing.
+            logger.warn("Couldn't read SVG dimensions from {}", svgFile.getName());
+        }
+        return null;
+    }
+
+    /** A length attribute that resolves to a fixed size (i.e. present and not a percentage). */
+    private static boolean isAbsolute(String dimension) {
+        return dimension != null && !dimension.isBlank() && !dimension.trim().endsWith("%");
+    }
+
+}

--- a/src/main/java/net/perspective/draw/util/SVGRead.java
+++ b/src/main/java/net/perspective/draw/util/SVGRead.java
@@ -80,7 +80,9 @@ public class SVGRead {
         float width = box != null ? box[0] : 0f;
         float height = box != null ? box[1] : 0f;
         try (InputStream file = new FileInputStream(svgFile)) {
-            return rasterize(new TranscoderInput(file), null, width, height, svgFile.getName());
+            // Files may be user-supplied (opened, dropped, or pasted from the clipboard),
+            // so treat them as untrusted and forbid external resource resolution.
+            return rasterize(new TranscoderInput(file), null, width, height, svgFile.getName(), false);
         }
     }
 
@@ -99,7 +101,8 @@ public class SVGRead {
         try (InputStream file = getClass().getResourceAsStream("/svg/" + filename)) {
             // A square box suits the icon glyphs: many declare only a viewBox (no width/height),
             // and Batik would otherwise leave its default height in place, distorting the result.
-            return rasterize(new TranscoderInput(file), fillColor, targetSize, targetSize, filename);
+            // Bundled resources are trusted, so external resource resolution stays enabled.
+            return rasterize(new TranscoderInput(file), fillColor, targetSize, targetSize, filename, true);
         }
     }
 
@@ -111,10 +114,13 @@ public class SVGRead {
      * @param targetWidth the output width in pixels, or {@code 0} to leave Batik's default
      * @param targetHeight the output height in pixels, or {@code 0} to leave Batik's default
      * @param name an identifier used for logging
+     * @param allowExternalResources whether the document may resolve external resources;
+     *     pass {@code false} for untrusted input to prevent it referencing local files or
+     *     remote URLs (SSRF / local-file disclosure)
      * @return a buffered image
      * @throws IOException
      */
-    private BufferedImage rasterize(TranscoderInput input, String fillColor, float targetWidth, float targetHeight, String name) throws IOException {
+    private BufferedImage rasterize(TranscoderInput input, String fillColor, float targetWidth, float targetHeight, String name, boolean allowExternalResources) throws IOException {
 
         final BufferedImage[] imagePointer = new BufferedImage[1];
 
@@ -140,7 +146,7 @@ public class SVGRead {
                 SVGConstants.SVG_NAMESPACE_URI);
         transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT, "svg");
         transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssFile.toUri().toString());
-        transcoderHints.put(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, Boolean.TRUE);
+        transcoderHints.put(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, allowExternalResources);
         if (targetWidth > 0f) {
             transcoderHints.put(SVGAbstractTranscoder.KEY_WIDTH, targetWidth);
         }

--- a/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
@@ -66,8 +66,6 @@ public class ImageLoadWorker extends Task<Object> {
     private List<File> imageFiles;
     private double shift;
     private boolean success;
-    private double pageWidth;      // canvas width pixels
-    private double pageHeight;     // canvas height pixels
 
     private static final Logger logger = LoggerFactory.getLogger(ImageLoadWorker.class.getName());
 
@@ -82,8 +80,6 @@ public class ImageLoadWorker extends Task<Object> {
 
     @Override
     protected Object call() throws Exception {
-        pageWidth = drawarea.getScene().getWidth();
-        pageHeight = drawarea.getScene().getHeight();
         this.imageFiles = share.getImageFiles();
         return new ImageLoader();
     }
@@ -102,7 +98,7 @@ public class ImageLoadWorker extends Task<Object> {
                     int index = view.setImageItem(item);
                     double width = (double) image.getWidth();
                     double height = (double) image.getHeight();
-                    double scale = getScale(width, height);
+                    double scale = drawarea.fitScale(width, height);
                     logger.trace("Image relative scale: {}", scale);
                     picture.setImage(index, width, height);
                     picture.setScale(scale);
@@ -166,39 +162,6 @@ public class ImageLoadWorker extends Task<Object> {
             }
         }
 
-    }
-
-    /**
-     * Get a representative scale for images larger than page size
-     * 
-     * 1. ImageWidth &gt; pageWidth resize to 80% pageWidth
-     * 2. ImageHeight &gt; pageHeight resize to 80% pageHeight
-     * 3. if imageSize &lt; pageSize do nothing
-     * 
-     * @param width
-     * @param height
-     * @return 
-     */
-    private double getScale(double width, double height) {
-        if ((width <= pageWidth) && (height <= pageHeight)) {
-            return 1d;
-        }
-        if ((width <= pageWidth) && (height > pageHeight)) {
-            return 0.8 * pageHeight / height;
-        }
-        if ((width > pageWidth) && (height <= pageHeight)) {
-            return 0.8 * pageWidth / width;
-        }
-        if ((width > pageWidth) && (height > pageHeight)) {
-            double ratio_w = pageWidth / width;
-            double ratio_h = pageHeight / height;
-            if (ratio_w <= ratio_h) {
-                return 0.8 * pageWidth / width;
-            } else {
-                return 0.8 * pageHeight / height;
-            }
-        }
-        return 1d;
     }
 
 }

--- a/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
@@ -23,12 +23,8 @@
  */
 package net.perspective.draw.workers;
 
-import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -47,14 +43,7 @@ import net.perspective.draw.ShareUtils;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.util.FileUtils;
 import net.perspective.draw.util.Messages;
-import org.apache.batik.anim.dom.SVGDOMImplementation;
-import org.apache.batik.transcoder.SVGAbstractTranscoder;
-import org.apache.batik.transcoder.TranscoderException;
-import org.apache.batik.transcoder.TranscoderInput;
-import org.apache.batik.transcoder.TranscoderOutput;
-import org.apache.batik.transcoder.TranscodingHints;
-import org.apache.batik.transcoder.image.ImageTranscoder;
-import org.apache.batik.util.SVGConstants;
+import net.perspective.draw.util.SVGRead;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +59,7 @@ public class ImageLoadWorker extends Task<Object> {
     private final CanvasView view;
     private final ApplicationController controller;
     @Inject ShareUtils share;
+    @Inject SVGRead svgRead;
     @Inject Provider<Picture> pictureProvider;
     private List<File> imageFiles;
     private double shift;
@@ -156,76 +146,13 @@ public class ImageLoadWorker extends Task<Object> {
             images = new ArrayList<>();
             for (File file : imageFiles) {
                 if (FileUtils.getExtension(file.getName()).equals("svg")) {
-                    images.add(SwingFXUtils.toFXImage(rasterize(file), null));
+                    images.add(SwingFXUtils.toFXImage(svgRead.rasterize(file), null));
                 } else {
                     images.add(SwingFXUtils.toFXImage(ImageIO.read(file), null));
                 }
             }
         }
 
-    }
-
-    /**
-     * Transcode SVG document 
-     * 
-     * @see <a href="https://stackoverflow.com/a/11436655">How to get a BufferedImage from a SVG?</a>
-     * 
-     * @param svgFile the file
-     * @return a buffered image
-     * @throws IOException 
-     */
-    public BufferedImage rasterize(File svgFile) throws IOException {
-
-        final BufferedImage[] imagePointer = new BufferedImage[1];
-
-        // Rendering hints can't be set programatically, so
-        // we override defaults with a temporary stylesheet.
-        // These defaults emphasize quality and precision, and
-        // are more similar to the defaults of other SVG viewers.
-        // SVG documents can still override these defaults.
-        String css = "svg {"
-            + "shape-rendering: geometricPrecision;"
-            + "text-rendering:  geometricPrecision;"
-            + "color-rendering: optimizeQuality;"
-            + "image-rendering: optimizeQuality;"
-            + "}";
-        Path cssFile = Files.createTempFile(Files.createTempDirectory("temp-dir"), "batik-default-override-", ".css");
-        FileUtils.writeStringToFile(cssFile.toFile(), css);
-        TranscodingHints transcoderHints = new TranscodingHints();
-        transcoderHints.put(ImageTranscoder.KEY_XML_PARSER_VALIDATING, Boolean.FALSE);
-        transcoderHints.put(ImageTranscoder.KEY_DOM_IMPLEMENTATION,
-            SVGDOMImplementation.getDOMImplementation());
-        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,
-            SVGConstants.SVG_NAMESPACE_URI);
-        transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT, "svg");
-        transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssFile.toUri().toString());
-        transcoderHints.put(SVGAbstractTranscoder.KEY_ALLOW_EXTERNAL_RESOURCES, Boolean.TRUE);
-
-        try {
-            TranscoderInput input = new TranscoderInput(new FileInputStream(svgFile));
-
-            ImageTranscoder t = new ImageTranscoder() {
-
-                @Override
-                public BufferedImage createImage(int w, int h) {
-                    return new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-                }
-
-                @Override
-                public void writeImage(BufferedImage image, TranscoderOutput out)
-                    throws TranscoderException {
-                    imagePointer[0] = image;
-                }
-            };
-            t.setTranscodingHints(transcoderHints);
-            t.transcode(input, null);
-        } catch (TranscoderException ex) {
-            logger.error("Couldn't convert {}", svgFile.getName());
-        } finally {
-            cssFile.toFile().deleteOnExit();
-        }
-
-        return imagePointer[0];
     }
 
     /**

--- a/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
@@ -23,6 +23,7 @@
  */
 package net.perspective.draw.workers;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
 public class ImageLoadWorker extends Task<Object> {
 
     private List<Image> images;
+    private List<File> loadedFiles;
     private final DrawingArea drawarea;
     private final CanvasView view;
     private final ApplicationController controller;
@@ -91,11 +93,12 @@ public class ImageLoadWorker extends Task<Object> {
         logger.info("Reading images complete.");
         Platform.runLater(() -> {
             if (!images.isEmpty()) {
-                for (Image image : images) {
+                for (int i = 0; i < images.size(); i++) {
+                    Image image = images.get(i);
                     Picture picture = pictureProvider.get();
                     picture.setStart(shift, shift);
                     ImageItem item = new ImageItem(image);
-                    item.setFormat(FileUtils.getExtension(imageFiles.get(images.indexOf(image))));
+                    item.setFormat(FileUtils.getExtension(loadedFiles.get(i)));
                     int index = view.setImageItem(item);
                     double width = (double) image.getWidth();
                     double height = (double) image.getHeight();
@@ -144,12 +147,22 @@ public class ImageLoadWorker extends Task<Object> {
 
         public void make() throws IOException {
             images = new ArrayList<>();
+            loadedFiles = new ArrayList<>();
             for (File file : imageFiles) {
+                BufferedImage buffered;
                 if (FileUtils.getExtension(file.getName()).equalsIgnoreCase("svg")) {
-                    images.add(SwingFXUtils.toFXImage(svgRead.rasterize(file), null));
+                    buffered = svgRead.rasterize(file);
                 } else {
-                    images.add(SwingFXUtils.toFXImage(ImageIO.read(file), null));
+                    buffered = ImageIO.read(file);
                 }
+                if (buffered == null) {
+                    // a corrupt/unsupported file or a failed SVG transcode; skip it rather
+                    // than NPE in toFXImage and abort the whole batch
+                    logger.warn("Couldn't read image {}", file.getName());
+                    continue;
+                }
+                images.add(SwingFXUtils.toFXImage(buffered, null));
+                loadedFiles.add(file);
             }
         }
 

--- a/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
@@ -145,7 +145,7 @@ public class ImageLoadWorker extends Task<Object> {
         public void make() throws IOException {
             images = new ArrayList<>();
             for (File file : imageFiles) {
-                if (FileUtils.getExtension(file.getName()).equals("svg")) {
+                if (FileUtils.getExtension(file.getName()).equalsIgnoreCase("svg")) {
                     images.add(SwingFXUtils.toFXImage(svgRead.rasterize(file), null));
                 } else {
                     images.add(SwingFXUtils.toFXImage(ImageIO.read(file), null));

--- a/src/main/java/net/perspective/draw/workers/SVGLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/SVGLoadWorker.java
@@ -62,8 +62,6 @@ public class SVGLoadWorker extends Task<Object> {
     private String markup;
     private double shift;
     private boolean success;
-    private double pageWidth;      // canvas width pixels
-    private double pageHeight;     // canvas height pixels
 
     private static final Logger logger = LoggerFactory.getLogger(SVGLoadWorker.class.getName());
 
@@ -87,8 +85,6 @@ public class SVGLoadWorker extends Task<Object> {
 
     @Override
     protected Object call() throws Exception {
-        pageWidth = drawarea.getScene().getWidth();
-        pageHeight = drawarea.getScene().getHeight();
         return new SVGLoader();
     }
 
@@ -104,7 +100,7 @@ public class SVGLoadWorker extends Task<Object> {
                 int index = view.setImageItem(item);
                 double width = (double) image.getWidth();
                 double height = (double) image.getHeight();
-                double scale = getScale(width, height);
+                double scale = drawarea.fitScale(width, height);
                 logger.trace("Image relative scale: {}", scale);
                 picture.setImage(index, width, height);
                 picture.setScale(scale);
@@ -157,39 +153,6 @@ public class SVGLoadWorker extends Task<Object> {
             image = SwingFXUtils.toFXImage(buffered, null);
         }
 
-    }
-
-    /**
-     * Get a representative scale for images larger than page size
-     *
-     * 1. ImageWidth &gt; pageWidth resize to 80% pageWidth
-     * 2. ImageHeight &gt; pageHeight resize to 80% pageHeight
-     * 3. if imageSize &lt; pageSize do nothing
-     *
-     * @param width
-     * @param height
-     * @return
-     */
-    private double getScale(double width, double height) {
-        if ((width <= pageWidth) && (height <= pageHeight)) {
-            return 1d;
-        }
-        if ((width <= pageWidth) && (height > pageHeight)) {
-            return 0.8 * pageHeight / height;
-        }
-        if ((width > pageWidth) && (height <= pageHeight)) {
-            return 0.8 * pageWidth / width;
-        }
-        if ((width > pageWidth) && (height > pageHeight)) {
-            double ratio_w = pageWidth / width;
-            double ratio_h = pageHeight / height;
-            if (ratio_w <= ratio_h) {
-                return 0.8 * pageWidth / width;
-            } else {
-                return 0.8 * pageHeight / height;
-            }
-        }
-        return 1d;
     }
 
 }

--- a/src/main/java/net/perspective/draw/workers/SVGLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/SVGLoadWorker.java
@@ -1,0 +1,195 @@
+/**
+ * SVGLoadWorker.java
+ *
+ * Created on Jun 28, 2026
+ *
+ */
+
+/**
+ * Copyright (c) 2026 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw.workers;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import javafx.application.Platform;
+import javafx.concurrent.Task;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.image.Image;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import net.perspective.draw.ApplicationController;
+import net.perspective.draw.CanvasView;
+import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ImageItem;
+import net.perspective.draw.ShareUtils;
+import net.perspective.draw.geom.Picture;
+import net.perspective.draw.util.Messages;
+import net.perspective.draw.util.SVGRead;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Rasterizes a single in-memory SVG document (e.g. pasted from the clipboard)
+ * onto the canvas off the FX thread, since transcoding can be slow.
+ *
+ * @author ctipper
+ */
+
+public class SVGLoadWorker extends Task<Object> {
+
+    private Image image;
+    private final DrawingArea drawarea;
+    private final CanvasView view;
+    private final ApplicationController controller;
+    @Inject ShareUtils share;
+    @Inject SVGRead svgRead;
+    @Inject Provider<Picture> pictureProvider;
+    private String markup;
+    private double shift;
+    private boolean success;
+    private double pageWidth;      // canvas width pixels
+    private double pageHeight;     // canvas height pixels
+
+    private static final Logger logger = LoggerFactory.getLogger(SVGLoadWorker.class.getName());
+
+    @Inject
+    public SVGLoadWorker(DrawingArea drawarea, CanvasView view, ApplicationController controller) {
+        this.drawarea = drawarea;
+        this.view = view;
+        this.controller = controller;
+        this.shift = 20.0;
+        success = false;
+    }
+
+    /**
+     * Set the SVG document markup to rasterize.
+     *
+     * @param markup the markup
+     */
+    public void setMarkup(String markup) {
+        this.markup = markup;
+    }
+
+    @Override
+    protected Object call() throws Exception {
+        pageWidth = drawarea.getScene().getWidth();
+        pageHeight = drawarea.getScene().getHeight();
+        return new SVGLoader();
+    }
+
+    @Override
+    public void done() {
+        logger.info("Reading SVG complete.");
+        Platform.runLater(() -> {
+            if (image != null) {
+                Picture picture = pictureProvider.get();
+                picture.setStart(shift, shift);
+                ImageItem item = new ImageItem(image);
+                item.setFormat("svg");
+                int index = view.setImageItem(item);
+                double width = (double) image.getWidth();
+                double height = (double) image.getHeight();
+                double scale = getScale(width, height);
+                logger.trace("Image relative scale: {}", scale);
+                picture.setImage(index, width, height);
+                picture.setScale(scale);
+                view.setNewItem(picture);
+                view.resetNewItem();
+            }
+        });
+        CompletableFuture.runAsync(() -> {
+            try {
+                // introduce a minimum visible interval
+                if (success) {
+                    Thread.sleep(300);
+                }
+            } catch (InterruptedException e) {
+            }
+        }, share.executor).thenRun(() -> {
+            Platform.runLater(() -> {
+                controller.getProgressVisibleProperty().setValue(Boolean.FALSE);
+                controller.getProgressProperty().unbind();
+                if (success) {
+                    controller.setStatusMessage(Messages.get("status.readPictures"));
+                }
+            });
+        });
+    }
+
+    final class SVGLoader {
+
+        SVGLoader() {
+            logger.info("Reading SVG initialised.");
+            try {
+                success = true;
+                this.make();
+            } catch (IOException e) {
+                logger.warn(e.getMessage());
+                success = false;
+            }
+        }
+
+        public void make() throws IOException {
+            if (markup == null) {
+                return;
+            }
+            BufferedImage buffered = svgRead.rasterize(markup);
+            if (buffered == null) {
+                // a failed transcode (e.g. malformed or externally-referencing SVG)
+                logger.warn("Couldn't rasterize pasted SVG");
+                return;
+            }
+            image = SwingFXUtils.toFXImage(buffered, null);
+        }
+
+    }
+
+    /**
+     * Get a representative scale for images larger than page size
+     *
+     * 1. ImageWidth &gt; pageWidth resize to 80% pageWidth
+     * 2. ImageHeight &gt; pageHeight resize to 80% pageHeight
+     * 3. if imageSize &lt; pageSize do nothing
+     *
+     * @param width
+     * @param height
+     * @return
+     */
+    private double getScale(double width, double height) {
+        if ((width <= pageWidth) && (height <= pageHeight)) {
+            return 1d;
+        }
+        if ((width <= pageWidth) && (height > pageHeight)) {
+            return 0.8 * pageHeight / height;
+        }
+        if ((width > pageWidth) && (height <= pageHeight)) {
+            return 0.8 * pageWidth / width;
+        }
+        if ((width > pageWidth) && (height > pageHeight)) {
+            double ratio_w = pageWidth / width;
+            double ratio_h = pageHeight / height;
+            if (ratio_w <= ratio_h) {
+                return 0.8 * pageWidth / width;
+            } else {
+                return 0.8 * pageHeight / height;
+            }
+        }
+        return 1d;
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds clipboard/drag-and-drop import of images onto the canvas, and refactors the
SVG rasterization path that makes it possible. Three layered changes:

1. **Shared `SVGRead`** — Batik transcoding extracted from `ApplicationController`
   and `ImageLoadWorker` into a single `util.SVGRead`, provided via Dagger.
2. **Image files from the file manager** — paste/drop jpg, jpeg, png, gif, svg.
3. **SVG markup from the clipboard** — paste raw `<svg>` text.

## Details

### Shared `SVGRead` (refactor)
- Factors the duplicated Batik transcode logic out of `ApplicationController` and
  `ImageLoadWorker` into `net.perspective.draw.util.SVGRead`, injected as a field.
- `rasterize(File)` for imported files; `rasterizeResource(name, fillColor, size)`
  for library icons.
- Library icons render into a square high-resolution box; viewBox-only SVGs are
  sized from their viewBox; inserted icons placed at 48×48.

### Image files (`CanvasTransferHandler`)
- Handles `DataFlavor.javaFileListFlavor`, filtering to jpg/jpeg/png/gif/svg.
- Loads through `ShareUtils.readPictures` → `ImageLoadWorker`, reusing its
  threading and progress indicator.
- `ImageLoadWorker` now matches the `svg` extension case-insensitively.

### SVG markup (`CanvasTransferHandler`)
- Detects SVG carried as `stringFlavor` (sniffs for `<svg`, `<!doctype svg`, or
  `<?xml … <svg`), spools it to a temporary `.svg`, and loads it via the same
  `readPictures` path.

### Import dispatch cleanup
- `importData` now resolves a typed `Flavor` enum and dispatches via a `switch`,
  with one handler method per payload (draw item, image, files, svg).
- Flavors are matched in priority order regardless of array order:
  **draw item → files → image → svg** (svg lowest). Image files rank above raw
  image data so they load through the svg-aware worker rather than being decoded
  eagerly.
- Resolved a Dagger initialization cycle (`CanvasTransferHandler` →
  `ShareUtils` → `CanvasView` → `DrawingArea` → `CanvasTransferHandler`) by
  injecting `Provider<ShareUtils>`.

## Testing
- `mvn -o compile` clean.
- App launches without DI errors; verified pasting image files from Finder loads
  them onto the canvas, and confirmed SVG markup paste rasterizes onto the canvas.
