### PR TITLE
Address canvas items by stable identity

### DIFF
--- a/src/main/java/net/perspective/draw/ApplicationController.java
+++ b/src/main/java/net/perspective/draw/ApplicationController.java
@@ -190,62 +190,62 @@ public class ApplicationController implements Initializable {
     private void handleLineAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.LINE);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleLineTypeAction(ActionEvent e) {
         this.setDrawAreaLineType();
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleCircleAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.ELLIPSE);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleSquareAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.RECTANGLE);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleTriangleAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.ISOSCELES);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleHexagonAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.HEXAGON);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handlePentagramAction(ActionEvent e) {
         drawareaProvider.get().setDrawType(DrawingType.PENTAGRAM);
         drawareaProvider.get().changeHandlers(HandlerType.FIGURE);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleSketchTypeAction(ActionEvent e) {
         this.setDrawAreaSketchType();
         drawareaProvider.get().changeHandlers(HandlerType.SKETCH);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML
     private void handleTextAction(ActionEvent e) {
         drawareaProvider.get().changeHandlers(HandlerType.TEXT);
-        viewProvider.get().setEditing(KeyHandlerType.NONE);
+        viewProvider.get().setEditing(KeyHandlerType.MOVE);
     }
 
     @FXML

--- a/src/main/java/net/perspective/draw/CanvasTransferHandler.java
+++ b/src/main/java/net/perspective/draw/CanvasTransferHandler.java
@@ -228,11 +228,10 @@ public class CanvasTransferHandler {
      *         is selected
      */
     protected Transferable createTransferable() {
-        int selected = viewProvider.get().getSelected();
-        if (selected == -1) {
+        DrawItem data = viewProvider.get().getSelectedDrawItem();
+        if (data == null) {
             return null;
         }
-        DrawItem data = viewProvider.get().getDrawings().get(selected);
         logger.trace("Item createTransferable");
         return new DrawItemTransferable(data);
     }

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -263,9 +263,10 @@ public class CanvasView {
      * Add item to canvas
      *
      * @param item the {@link net.perspective.draw.geom.DrawItem}
+     * @return the id of the slot the item was placed in
      */
-    public void appendItemToCanvas(DrawItem item) {
-        store.append(item);
+    public ItemId appendItemToCanvas(DrawItem item) {
+        return store.append(item);
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -713,17 +713,37 @@ public class CanvasView {
     }
 
     /**
-     * Add a DrawItem to the selection by index.
+     * Select a DrawItem by index and show the selection.
      *
-     * <p>Compatibility shim for call sites not yet migrated. Resolves the index against the
-     * current snapshot immediately, so the stored id is stable even though the index was not.
-     * Prefer {@link #setSelectedId} where an id is already to hand.</p>
+     * <p>Compatibility shim; prefer {@link #setSelected(ItemId)}.</p>
      *
      * @param selection the index, or -1 to clear
      */
     public void setSelected(int selection) {
-        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         if (selection == -1) {
+            setSelected((ItemId) null);
+            return;
+        }
+        List<ItemId> order = store.getItems();
+        if (selection < 0 || selection >= order.size()) {
+            return;                                  // stale index; leave selection untouched
+        }
+        setSelected(order.get(selection));
+    }
+
+    /**
+     * Select a DrawItem and show the selection.
+     *
+     * <p>Distinct from {@link #setSelectedId}, which only records membership. This also redraws
+     * the anchors, the rotation pivot and the caret highlight, so it is what to call when the
+     * selection changes outside a mouse gesture — restoring one after a modal interlude, say.
+     * Within a gesture the handler's mouse-up already refreshes the overlay.</p>
+     *
+     * @param id the slot id, or null to clear
+     */
+    public void setSelected(ItemId id) {
+        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
+        if (id == null) {
             nodes.remove(drawingAnchors);
             nodes.remove(highlight);
             nodes.remove(itemPivot);
@@ -733,8 +753,9 @@ public class CanvasView {
             return;
         }
         Snapshot snap = store.snapshot();
-        if (selection < 0 || selection >= snap.size()) {
-            return;                                  // stale index; leave selection untouched
+        DrawItem item = snap.get(id);
+        if (item == null) {
+            return;                                  // stale id; leave selection untouched
         }
         nodes.remove(drawingAnchors);
         nodes.remove(highlight);
@@ -743,14 +764,14 @@ public class CanvasView {
             selectionIds.clear();
             drawingAnchors.getChildren().clear();
         }
-        setSelectedId(snap.order().get(selection));  // must precede getAnchors(), which reads the selection
+        setSelectedId(id);                           // must precede getAnchors(), which reads the selection
         drawingAnchors = getAnchors(snap);
         nodes.add(drawingAnchors);
         if (drawarea.isRotationMode()) {
-            itemPivot = g2.drawRotationPivot(snap.at(selection));
+            itemPivot = g2.drawRotationPivot(item);
             nodes.add(itemPivot);
         }
-        setTextHighlight(selection);
+        setTextHighlight(id);
     }
 
     /**
@@ -777,6 +798,18 @@ public class CanvasView {
         int before = selectionIds.size();
         selectionIds.removeIf(id -> snap.get(id) == null);
         return before - selectionIds.size();
+    }
+
+    /**
+     * Redraw the overlay for whatever is currently selected.
+     *
+     * <p>The common case by far: an item has been moved, resized or restyled in place and the
+     * anchors need to follow it. Replaces {@code moveSelection(getSelected())}, which resolved the
+     * selection to an index only to resolve it straight back again — and silently did nothing if
+     * the two resolutions disagreed.</p>
+     */
+    public void refreshSelection() {
+        moveSelection(this.getSelectedId());
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -983,6 +983,20 @@ public class CanvasView {
     }
 
     /**
+     * The primary selected item.
+     *
+     * <p>Null is the ordinary outcome for "nothing selected" <em>and</em> for a selection whose
+     * item has since been removed, so callers null-check once here instead of testing
+     * {@code getSelected() != -1} and then indexing — a pair that reads as safe but resolves the
+     * selection twice, and throws if the document changed in between.</p>
+     *
+     * @return the selected {@link net.perspective.draw.geom.DrawItem}, or null
+     */
+    public DrawItem getSelectedDrawItem() {
+        return store.lookupId(this.getSelectedId());
+    }
+
+    /**
      * Lowest member of the multi-selection in z-order.
      *
      * @return the id, or null if the selection is empty or fully stale

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -930,9 +930,14 @@ public class CanvasView {
         ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         nodes.remove(highlight);
         if (isEditing()) {
-            DrawItem item = store.lookupId(id);
-            if (item == null) {
-                return;                              // nothing selected, or stale; no caret drawn
+            /*
+             * Only a Text carries a caret, and g2.highlightText casts to one. Edit mode and the
+             * selection are set independently, so they can disagree for an instant — restoring a
+             * selection while edit mode is still on, say — and a bare lookup would hand a Grouped
+             * or a Figure to that cast.
+             */
+            if (!(store.lookupId(id) instanceof Text item)) {
+                return;                              // nothing selected, stale, or not a text item
             }
             highlight = g2.highlightText(item);
             if (textController.getEditor().getCaretStart() == textController.getEditor().getCaretEnd()) {

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -1106,10 +1106,19 @@ public class CanvasView {
     }
 
     /**
-     * @return true if nothing is selected
+     * Is there a selection that still resolves to an item.
+     *
+     * <p>Equivalent to the {@code getSelected() != -1} it replaces, but a hash lookup rather than
+     * an O(n) scan of the z-order — the old form built the answer by finding the item's index and
+     * then discarding it.</p>
+     *
+     * <p>Resolution, not set membership: a selection whose item has since been removed reads as no
+     * selection, which is what a caller about to act on that item wants to know.</p>
+     *
+     * @return true if an item is selected and still present
      */
-    public boolean hasNoSelection() {
-        return selectionIds.isEmpty();
+    public boolean hasSelection() {
+        return this.getSelectedDrawItem() != null;
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -31,6 +31,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -397,61 +398,114 @@ public class CanvasView {
     }
 
     /**
-     * Update the properties of the selected item or select properties
-     * of the selected item if dropper is enabled
+     * Apply the canvas properties to the selected items, or read the properties of the primary
+     * selection when the dropper is enabled.
+     *
+     * <p>Applies to every member of the multi-selection. Members removed since selection are
+     * skipped rather than treated as an error.</p>
+     *
+     * <p>The toolbar calls this whenever a property changes, and it reaches every selected item.
+     * The pointer handlers call it too, but only for a single selection — see
+     * {@link #isSingleSelection()}; on a multi-selection they call {@link #pickSelectedItem()},
+     * which reads without writing.</p>
      */
     public void updateSelectedItem() {
-        if (this.getSelected() != -1 && controller.getDropperDisabled()) {
-            /**
-             * Update item properties
-             */
-            DrawItem item = store.lookupId(this.getSelected());
+        if (!this.hasSelection()) {
+            return;                                  // nothing selected, or stale
+        }
+
+        if (!controller.getDropperDisabled()) {
+            this.pickSelectedItem();
+            return;
+        }
+
+        /**
+         * ONE snapshot for the whole pass. The replacements are computed first and applied in a
+         * single batch: replaceItem publishes per call, and a multi-selection would otherwise
+         * queue one snapshot rebuild per member. Text layout runs outside the store lock.
+         */
+        Snapshot snap = store.snapshot();
+        Map<ItemId, DrawItem> updates = new LinkedHashMap<>();
+        for (ItemId id : this.getSelectionInZOrder(snap)) {
+            DrawItem item = snap.get(id);
             if (item == null) {
-                return;                              // stale selection
+                continue;                            // removed since selection
             }
+            updates.put(id, applyProperties(item));
+        }
+        if (updates.isEmpty()) {
+            return;
+        }
+        store.batch(() -> updates.forEach(store::replaceItem));
+    }
 
-            if (!this.isMultiSelected() && !drawarea.isMultiSelectEnabled()) {
-                item.updateProperties(drawarea);
-            }
-
-            switch (item) {
-                case Figure figure when !(figure instanceof ArrowLine) -> {
-                    FigureType type = figure.getType();
-                    if (drawarea.getArrow() != ArrowType.NONE) {
-                        if (type.equals(FigureType.SKETCH) || type.equals(FigureType.LINE)) {
-                            item = new ArrowLine(figure);
-                            item.updateProperties(drawarea);
-                        }
-                    }
-                }
-                case ArrowLine arrowLine -> {
-                    if (drawarea.getArrow() == ArrowType.NONE) {
-                        item = arrowLine.getLine();
-                        item.updateProperties(drawarea);
-                    } else {
-                        item.updateProperties(drawarea);
-                    }
-                }
-                default -> {
-                }
-            }
-
-            this.updateCanvasItem(this.getSelected(), item);
-        } else if (this.getSelected() != -1 && !controller.getDropperDisabled()) { // dropper enabled
-            /**
-             * Select item properties and update UI
-             */
-            DrawItem item = store.lookupId(this.getSelected());
-            if (item == null) {
-                return;                              // stale selection
-            }
-            switch (item) {
-                case Figure figure -> this.figureDropper(figure);
-                case Text text -> this.textDropper(text);
-                default -> {
-                }
+    /**
+     * Read the properties of the primary selection into the UI, when the dropper is enabled.
+     *
+     * <p>Picking up properties from several items at once has no meaning, so only the primary
+     * selection is read. This writes to the canvas properties, not to the document, so it is safe
+     * to call on selection — where applying properties would not be — and nothing needs
+     * repainting afterwards.</p>
+     */
+    public void pickSelectedItem() {
+        if (controller.getDropperDisabled()) {
+            return;
+        }
+        DrawItem item = this.getSelectedDrawItem();
+        if (item == null) {
+            return;                                  // nothing selected, or stale
+        }
+        switch (item) {
+            case Figure figure -> this.figureDropper(figure);
+            case Text text -> this.textDropper(text);
+            default -> {
             }
         }
+    }
+
+    /**
+     * Apply the canvas properties to an item, converting between
+     * {@link net.perspective.draw.geom.Figure} and {@link net.perspective.draw.geom.ArrowLine}
+     * as the current arrow setting requires.
+     *
+     * <p>Returns the item to store: the same instance when only properties changed, a new one
+     * when the arrow setting forced a conversion. The caller rebinds the slot either way, so the
+     * node is refreshed and the revision moves.</p>
+     *
+     * @param item the {@link net.perspective.draw.geom.DrawItem}
+     * @return the item to store
+     */
+    private DrawItem applyProperties(DrawItem item) {
+        DrawItem result = item;
+
+        switch (result) {
+            case Figure figure when !(figure instanceof ArrowLine) -> {
+                FigureType type = figure.getType();
+                if (drawarea.getArrow() != ArrowType.NONE) {
+                    if (type.equals(FigureType.SKETCH) || type.equals(FigureType.LINE)) {
+                        result = new ArrowLine(figure);
+                    }
+                }
+            }
+            case ArrowLine arrowLine -> {
+                if (drawarea.getArrow() == ArrowType.NONE) {
+                    /**
+                     * getLine() is unset on an ArrowLine built by the no-arg constructor — the
+                     * one the reader uses — so unwrap only when there is a line to unwrap to,
+                     * rather than storing a null item.
+                     */
+                    Figure line = arrowLine.getLine();
+                    if (line != null) {
+                        result = line;
+                    }
+                }
+            }
+            default -> {
+            }
+        }
+
+        result.updateProperties(drawarea);
+        return result;
     }
 
     private void figureDropper(Figure item) {
@@ -1108,6 +1162,21 @@ public class CanvasView {
      */
     public boolean isMultiSelected() {
         return selectionIds.size() > 1;
+    }
+
+    /**
+     * Is exactly one item selected.
+     *
+     * <p>The distinction the pointer handlers draw: a single selection is reapplied the canvas
+     * properties at the end of a gesture, as it always was, while a multi-selection is restyled
+     * only when the user changes a property in the toolbar — pointer work must not conform its
+     * members to the current settings. False while a marquee is still collecting members, since
+     * {@code isMultiSelectEnabled} marks a selection in progress that may yet grow.</p>
+     *
+     * @return true if the selection holds one id and is not still being collected
+     */
+    public boolean isSingleSelection() {
+        return selectionIds.size() == 1 && !drawarea.isMultiSelectEnabled();
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -281,6 +281,18 @@ public class CanvasView {
     }
 
     /**
+     * Update the item bound to a slot
+     *
+     * @param id the slot id
+     * @param item the {@link net.perspective.draw.geom.DrawItem}
+     */
+    public void updateCanvasItem(ItemId id, DrawItem item) {
+        if (id != null) {
+            store.replaceItem(id, item);
+        }
+    }
+
+    /**
      * Delete the selected item
      */
     public void deleteSelectedItem() {
@@ -770,9 +782,25 @@ public class CanvasView {
     /**
      * Move the selection and update drawing anchors
      *
+     * <p>Compatibility shim; prefer {@link #moveSelection(ItemId)}.</p>
+     *
      * @param selection selected index
      */
     public void moveSelection(int selection) {
+        List<ItemId> order = store.getItems();
+        moveSelection(selection < 0 || selection >= order.size() ? null : order.get(selection));
+    }
+
+    /**
+     * Move the selection and update drawing anchors
+     *
+     * <p>The anchors are dropped first and rebuilt from the current geometry, so this is the
+     * refresh to call after an item has been moved or resized in place. A null or stale id leaves
+     * the anchors cleared.</p>
+     *
+     * @param id the slot id, or null
+     */
+    public void moveSelection(ItemId id) {
         ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         if (!drawingAnchors.getChildren().isEmpty()) {
             nodes.remove(drawingAnchors);
@@ -780,34 +808,44 @@ public class CanvasView {
             nodes.remove(itemPivot);
             drawingAnchors.getChildren().clear();
         }
-        if (selection == -1) {
-            return;
-        }
         Snapshot snap = store.snapshot();
-        if (selection < 0 || selection >= snap.size()) {
-            return;                                  // stale index; anchors already cleared
+        DrawItem item = snap.get(id);
+        if (item == null) {
+            return;                                  // nothing selected, or stale
         }
         drawingAnchors = getAnchors(snap);
         nodes.add(drawingAnchors);
         if (drawarea.isRotationMode()) {
-            itemPivot = g2.drawRotationPivot(snap.at(selection));
+            itemPivot = g2.drawRotationPivot(item);
             nodes.add(itemPivot);
         }
-        setTextHighlight(selection);
+        setTextHighlight(id);
     }
 
     /**
      * Provide a cursor whilst editing text
-     * 
+     *
+     * <p>Compatibility shim; prefer {@link #setTextHighlight(ItemId)}.</p>
+     *
      * @param selection index of the current drawitem
      */
     public void setTextHighlight(int selection) {
+        List<ItemId> order = store.getItems();
+        setTextHighlight(selection < 0 || selection >= order.size() ? null : order.get(selection));
+    }
+
+    /**
+     * Provide a cursor whilst editing text
+     *
+     * @param id the slot id of the current drawitem
+     */
+    public void setTextHighlight(ItemId id) {
         ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         nodes.remove(highlight);
         if (isEditing()) {
-            DrawItem item = store.lookupId(selection);
+            DrawItem item = store.lookupId(id);
             if (item == null) {
-                return;                              // stale index; caret simply not drawn
+                return;                              // nothing selected, or stale; no caret drawn
             }
             highlight = g2.highlightText(item);
             if (textController.getEditor().getCaretStart() == textController.getEditor().getCaretEnd()) {

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -269,6 +269,19 @@ public class CanvasView {
     }
 
     /**
+     * Add several items to the top of the canvas as one publication.
+     *
+     * <p>Appending in a loop instead rebuilds the snapshot per item, which is O(n²) across the
+     * batch. Unlike {@link #loadItemsToCanvas} this adds to the document rather than replacing it,
+     * so ids held elsewhere stay valid and the selection is left alone.</p>
+     *
+     * @param items the {@link net.perspective.draw.geom.DrawItem}s in z-order
+     */
+    public void appendItemsToCanvas(List<DrawItem> items) {
+        store.insertAll(store.size(), items);
+    }
+
+    /**
      * Replace the document with the contents of a file.
      *
      * <p>Images are installed before the items, and this ordering is required rather than tidy: a

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -331,6 +331,22 @@ public class CanvasView {
     }
 
     /**
+     * Republish the selected item after editing it in place.
+     *
+     * <p>Text editing mutates the {@link net.perspective.draw.geom.Text} already in the store —
+     * resizing it via {@code setDimensions} in particular — rather than replacing it. The store
+     * cannot see that write, so nothing refreshes the node and the revision does not move. Call
+     * this after any such edit.</p>
+     *
+     * <p>Distinct from {@link #updateSelectedItem()}, which also reapplies the canvas properties
+     * and so is the wrong call when only the geometry changed. No-op when nothing is selected or
+     * the item has gone.</p>
+     */
+    public void commitSelection() {
+        store.touch(this.getSelectedId());
+    }
+
+    /**
      * Delete the selected item
      */
     public void deleteSelectedItem() {

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -30,14 +30,14 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
-import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.Group;
 import javafx.scene.Node;
@@ -53,6 +53,7 @@ import net.perspective.draw.util.CanvasPoint;
 import net.perspective.draw.util.G2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import net.perspective.draw.ItemStore.Snapshot;
 
 /**
  * 
@@ -65,13 +66,15 @@ public class CanvasView {
     private final DrawingArea drawarea;
     private final ApplicationController controller;
     private final TextController textController;
+    @Inject ItemStore store;
+    @Inject FxSnapshotBinder binder;
     @Inject Dropper dropper;
     @Inject G2 g2;
-    private final List<DrawItem> list;
-    private ObservableList<DrawItem> drawings;
     private final List<ImageItem> images;
+    private final Set<ItemId> selectionIds;
+    /** The scene node currently rendering each slot. FX thread only. */
+    private final Map<ItemId, Node> itemNodes;
     private Optional<DrawItem> newitem;
-    private final Set<Integer> selectionIndex;
     private final Timeline caretTimeline;
     private Group drawingAnchors;
     private Node drawMarquee;
@@ -84,6 +87,15 @@ public class CanvasView {
     private boolean isMarquee;
     private boolean hasGuides;
 
+    /**
+     * Node id prefix of the grid layer, set by {@link G2#drawGridLayout}. Matched as a prefix
+     * because {@code redrawGrid} identifies its own nodes the same way.
+     */
+    private static final String GRID_ID = "grid";
+
+    /** Node id of the guides layer, so {@link #itemBase} can recognise it. */
+    static final String GUIDES_ID = "guides";
+
     private static final Logger logger = LoggerFactory.getLogger(CanvasView.class.getName());
 
     /**
@@ -94,10 +106,10 @@ public class CanvasView {
         this.drawarea = drawarea;
         this.controller = controller;
         this.textController = textController;
-        this.list = new ArrayList<>();
         this.images = new ArrayList<>();
+        this.selectionIds = new LinkedHashSet<>();
+        this.itemNodes = new HashMap<>();
         newitem = Optional.empty();
-        this.selectionIndex = new LinkedHashSet<>();
         this.drawingAnchors = new Group();
         this.itemPivot = new Group();
         /**
@@ -120,55 +132,131 @@ public class CanvasView {
     }
 
     /**
+     * Is the item store empty
+     * 
+     * @return is empty
+     */
+    public boolean isEmpty() {
+        return store.isEmpty();
+    }
+
+    /**
      * Remove contents of drawing list
      */
     private void deleteContents() {
-        drawings.clear();
+        store.clear();
         images.clear();
     }
 
     /**
-     * Listener operates on drawing list to handle updates
+     * Mirror the item store onto the canvas
+     *
+     * <p>Replaces the former {@code ObservableList} listener. The store publishes from whichever
+     * thread wrote, so {@link FxSnapshotBinder} coalesces publications onto the FX thread and
+     * reports what actually changed by {@link ItemId}; this class only has to maintain the node
+     * for each slot.</p>
      */
     public void setDrawingListener() {
-        drawings = FXCollections.observableList(list);
-        drawings.addListener((ListChangeListener.Change<? extends DrawItem> change) -> {
-            while (change.next()) {
+        binder.setItemListener(new FxSnapshotBinder.ItemListener() {
+
+            @Override
+            public void added(ItemId id, DrawItem item, int index) {
+                Node node = item.draw();
+                itemNodes.put(id, node);
+                drawarea.getCanvas().getChildren().add(itemBase() + index, node);
+                logger.trace("node added at {}", index);
+            }
+
+            @Override
+            public void rebound(ItemId id, DrawItem item) {
                 ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
-                int g = (drawarea.isGridVisible() ? 1 : 0);
-                if (hasGuides()) g += 1;
-                if (change.wasPermutated()) {
-                    for (int i = change.getFrom(); i < change.getTo(); ++i) {
-                        // permutate
-                        nodes.set(change.getPermutation(i) + g, drawings.get(i).draw());
-                        logger.trace("node " + change.getPermutation(i) + " updated from " + i);
-                    }
-                } else if (change.wasUpdated()) {
-                    for (int i = change.getFrom(); i < change.getTo(); ++i) {
-                        // update item
-                        nodes.set(i + g, drawings.get(i).draw());
-                        logger.trace("node " + i + " updated");
-                    }
-                } else {
-                    if (change.wasRemoved()) {
-                        for (int j = 0; j < change.getRemovedSize(); j++) {
-                            // remove item
-                            nodes.remove(change.getFrom() + g);
-                            logger.trace("node " + change.getFrom() + " removed.");
-                        }
-                    }
-                    if (change.wasAdded()) {
-                        int i = 0;
-                        for (DrawItem additem : change.getAddedSubList()) {
-                            // add item
-                            nodes.add(change.getFrom() + i + g, additem.draw());
-                            i++;
-                            logger.trace("node added");
-                        }
-                    }
+                Node previous = itemNodes.get(id);
+                int at = previous == null ? -1 : nodes.indexOf(previous);
+                if (at == -1) {
+                    return;                          // never rendered; the restack will place it
+                }
+                Node node = item.draw();
+                nodes.set(at, node);                 // in place: no index arithmetic
+                itemNodes.put(id, node);
+                logger.trace("node {} updated", at);
+            }
+
+            @Override
+            public void removed(ItemId id) {
+                Node node = itemNodes.remove(id);
+                if (node != null) {
+                    drawarea.getCanvas().getChildren().remove(node);
+                    logger.trace("node removed");
                 }
             }
+
+            @Override
+            public void reordered() {
+                restack();
+            }
         });
+        binder.attach();
+    }
+
+    /**
+     * Index of the first item node among the canvas children
+     *
+     * <p>The canvas holds leading chrome — the grid and the guides, each inserted at index 0 by
+     * {@link DrawingArea#redrawGrid} and {@link #setGuides} — then the item nodes, then whatever
+     * has been appended: the anchors, the caret highlight, the rotation pivot, and the map
+     * controls. Only the leading chrome shifts the item region, and appending never does.</p>
+     *
+     * <p>Counted from the scene graph rather than from {@code isGridVisible()} and
+     * {@code hasGuides()}. Those flags are set in one place and the nodes added in another, so a
+     * moment where they disagree would silently offset every subsequent index by one, corrupting
+     * the wrong node rather than failing.</p>
+     *
+     * @return the index at which item nodes begin
+     */
+    private int itemBase() {
+        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
+        int base = 0;
+        while (base < nodes.size() && isChrome(nodes.get(base))) {
+            base++;
+        }
+        return base;
+    }
+
+    /**
+     * @param node a canvas child
+     * @return true if it is leading chrome rather than an item
+     */
+    private static boolean isChrome(Node node) {
+        String id = node.getId();
+        return id != null && (id.startsWith(GRID_ID) || id.equals(GUIDES_ID));
+    }
+
+    /**
+     * Restack the item nodes to match the store's z-order
+     *
+     * <p>Checks before mutating: an add or a remove already leaves the region in order, and only a
+     * genuine reposition needs the list rebuilt. The nodes are reused, so this restacks rather than
+     * redrawing.</p>
+     */
+    private void restack() {
+        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
+        List<Node> ordered = new ArrayList<>(binder.getOrder().size());
+        for (ItemId id : binder.getOrder()) {
+            Node node = itemNodes.get(id);
+            if (node != null) {
+                ordered.add(node);
+            }
+        }
+        int base = itemBase();
+        boolean inOrder = base + ordered.size() <= nodes.size();
+        for (int i = 0; inOrder && i < ordered.size(); i++) {
+            inOrder = nodes.get(base + i) == ordered.get(i);
+        }
+        if (inOrder) {
+            return;
+        }
+        nodes.removeAll(ordered);
+        nodes.addAll(itemBase(), ordered);            // recomputed: removal cannot shift the chrome
     }
 
     /**
@@ -177,18 +265,18 @@ public class CanvasView {
      * @param item the {@link net.perspective.draw.geom.DrawItem}
      */
     public void appendItemToCanvas(DrawItem item) {
-        drawings.add(item);
+        store.append(item);
     }
 
     /**
      * Update the canvas item at given index
-     * 
+     *
      * @param selection item index
      * @param item the {@link net.perspective.draw.geom.DrawItem}
      */
     public void updateCanvasItem(int selection, DrawItem item) {
         if (selection != -1) {
-            drawings.set(selection, item);
+            store.replaceItem(selection, item);      // keeps the slot id, so the node is rebound
         }
     }
 
@@ -196,9 +284,10 @@ public class CanvasView {
      * Delete the selected item
      */
     public void deleteSelectedItem() {
-        if (this.getSelected() != -1) {
-            drawings.remove(this.getSelected());
-            setSelected(-1);
+        ItemId id = this.getSelectedId();
+        if (id != null) {
+            setSelected(-1);                         // drops the anchors before the item goes
+            store.removeById(id);
         }
     }
 
@@ -220,7 +309,7 @@ public class CanvasView {
         if (newitem.isEmpty()) {
             this.appendItemToCanvas(item);
         } else {
-            this.updateCanvasItem(drawings.size() - 1, item);
+            this.updateCanvasItem(store.size() - 1, item);
         }
         newitem = Optional.of(item);
     }
@@ -250,7 +339,10 @@ public class CanvasView {
             /**
              * Update item properties
              */
-            DrawItem item = drawings.get(this.getSelected());
+            DrawItem item = store.lookupId(this.getSelected());
+            if (item == null) {
+                return;                              // stale selection
+            }
 
             if (!this.isMultiSelected() && !drawarea.isMultiSelectEnabled()) {
                 item.updateProperties(drawarea);
@@ -283,7 +375,10 @@ public class CanvasView {
             /**
              * Select item properties and update UI
              */
-            DrawItem item = drawings.get(this.getSelected());
+            DrawItem item = store.lookupId(this.getSelected());
+            if (item == null) {
+                return;                              // stale selection
+            }
             switch (item) {
                 case Figure figure -> this.figureDropper(figure);
                 case Text text -> this.textDropper(text);
@@ -350,126 +445,134 @@ public class CanvasView {
         drawarea.updateFontStyle(fontStyle);
     }
 
+// ---------------------------------------------------------------------------
+// Z-order
+// ---------------------------------------------------------------------------
+
     /**
      * Send DrawItem backwards in drawing list
+     *
+     * <p>{@link ItemStore#move} repositions the slot without minting a new id, so the item stays
+     * selected across the move and no re-selection is needed here. The same holds for the three
+     * methods below.</p>
      */
     public void sendBackwards() {
-        if (this.getSelected() != -1) {
-            DrawItem item = drawings.get(this.getSelected());
-            if (this.getSelected() > 0) {
-                int selection = this.getSelected();
-                drawings.remove(selection);
-                if (selection < 2) {
-                    drawings.add(0, item);
-                } else {
-                    drawings.add(selection - 1, item);
-                }
-            }
+        int selection = this.getSelected();
+        if (selection <= 0) {
+            return;                                  // nothing selected, or already at back
         }
+        /*
+         * The original special-cased selection < 2 to insert at 0. That branch was redundant:
+         * for selection == 1, selection - 1 is already 0.
+         */
+        store.move(selection, selection - 1);
     }
 
     /**
      * Send DrawItem to back of drawing list
      */
     public void sendToBack() {
-        if (this.getSelected() != -1) {
-            DrawItem item = drawings.get(this.getSelected());
-            if (this.getSelected() != 0) {
-                int selection = this.getSelected();
-                drawings.remove(selection);
-                drawings.add(0, item);
-            }
+        int selection = this.getSelected();
+        if (selection <= 0) {
+            return;
         }
+        store.move(selection, 0);
     }
 
     /**
      * Bring DrawItem forwards in drawing list
      */
     public void bringForwards() {
-        if (this.getSelected() != -1) {
-            DrawItem item = drawings.get(this.getSelected());
-            if (this.getSelected() < (drawings.size() - 1)) {
-                int selection = this.getSelected();
-                drawings.remove(selection);
-                if (selection >= (drawings.size() - 1)) {
-                    drawings.add(item);
-                } else {
-                    drawings.add(selection + 1, item);
-                }
-            }
+        int selection = this.getSelected();
+        if (selection == -1 || selection >= store.size() - 1) {
+            return;                                  // nothing selected, or already at front
         }
+        /*
+         * The original special-cased selection >= size - 2 to append. Also redundant: removing
+         * selection and then inserting at selection + 1 lands the item at the end either way.
+         */
+        store.move(selection, selection + 1);
     }
 
     /**
      * Bring DrawItem to front of drawing list
      */
     public void bringToFront() {
-        if (this.getSelected() != -1) {
-            DrawItem item = drawings.get(this.getSelected());
-            if (this.getSelected() != drawings.size() - 1) {
-                int selection = this.getSelected();
-                drawings.remove(selection);
-                drawings.add(item);
-            }
+        int selection = this.getSelected();
+        int last = store.size() - 1;
+        if (selection == -1 || selection == last) {
+            return;
         }
+        store.move(selection, last);
     }
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
 
     /**
      * Group selected DrawItems
+     *
+     * <p>Members are added to the {@link Grouped} in z-order rather than the order they were
+     * selected in, so the group renders identically to the loose items it replaces. The group
+     * takes over the bottom-most member's slot, keeping that id and its position in the z-order;
+     * the other members are removed. Both mutations publish as one snapshot, so no reader observes
+     * the group and its members coexisting.</p>
      */
     public void groupSelection() {
-        if (this.getSelected() != -1) {
-            Grouped groupedItem = new Grouped();
-            List<DrawItem> removals = new ArrayList<>();
-            List<Integer> selection =  new ArrayList<>();
-            Integer selected = this.getBottomSelected();
-
-            // create a Grouped item and queue items for removal
-            for (Integer index : this.getMultiSelection()) {
-                groupedItem.addDrawItem(drawings.get(index));
-                selection.add(index);
-            }
-            // reverse sort removals
-            Collections.reverse(selection);
-            for (Integer index : selection) {
-                removals.add(drawings.get(index));
-            }
-
-            this.setSelected(-1);
-
-            // delete drawings
-            for (DrawItem item : removals) {
-                drawings.remove(item);
-            }
-            
-            // replace selected
-            drawings.add(selected, groupedItem);
+        Snapshot snap = store.snapshot();            // one snapshot for the whole operation
+        List<ItemId> members = getSelectionInZOrder(snap);
+        if (members.isEmpty()) {
+            return;                                  // nothing selected, or the selection went stale
         }
+
+        ItemId bottom = members.get(0);
+        Grouped groupedItem = new Grouped();
+        List<ItemId> removals = new ArrayList<>(members.size() - 1);
+        for (ItemId id : members) {
+            groupedItem.addDrawItem(snap.get(id));   // non-null: getSelectionInZOrder dropped the rest
+            if (!id.equals(bottom)) {
+                removals.add(id);                    // the bottom slot is replaced, not removed
+            }
+        }
+
+        int bottomIndex = snap.indexOf(bottom);
+        this.setSelected(-1);                        // also clears selectionIds
+        store.batch(() -> {
+            store.replaceItem(bottomIndex, groupedItem);
+            store.removeAllById(removals);           // all above bottomIndex, which therefore holds
+        });
     }
 
     /**
      * Explode selected DrawItem group
+     *
+     * <p>The first member takes over the group's slot, keeping its id and z-position; the rest are
+     * inserted immediately above it, in order. Both mutations publish as one snapshot.</p>
      */
     public void ungroupSelection() {
-        if (this.getSelected() != -1) {
-            int selected = this.getBottomSelected();
-            DrawItem item = drawings.get(selected);
-            if (item instanceof Grouped grouped) {
-                boolean added = false;
-                for (DrawItem shape : grouped.getDrawItems()) {
-                    if (!added) {
-                        // replace selected
-                        drawings.set(selected, shape);
-                        added = true;
-                    } else {
-                        // add drawings
-                        drawings.add(selected, shape);
-                    }
-                    selected++;
-                }
-                this.setSelected(-1);
-            }
+        Snapshot snap = store.snapshot();
+        List<ItemId> members = getSelectionInZOrder(snap);
+        if (members.isEmpty()) {
+            return;
         }
+        ItemId groupId = members.get(0);
+        if (!(snap.get(groupId) instanceof Grouped grouped)) {
+            return;                                  // bottom-most selection is not a group
+        }
+
+        List<DrawItem> shapes = grouped.getDrawItems();
+        int selected = snap.indexOf(groupId);        // non-negative: the id resolved against snap
+        this.setSelected(-1);
+        if (shapes.isEmpty()) {
+            return;                                  // degenerate group; leave the slot as it is
+        }
+        store.batch(() -> {
+            store.replaceItem(selected, shapes.get(0));
+            if (shapes.size() > 1) {
+                store.insertAll(selected + 1, shapes.subList(1, shapes.size()));
+            }
+        });
     }
 
     /**
@@ -486,11 +589,15 @@ public class CanvasView {
 
     /**
      * Get the list of draw items
-     * 
-     * @return list of {@link net.perspective.draw.geom.DrawItem}
+     *
+     * <p>A copy taken from the store's current snapshot, not the live list the old backing
+     * {@code ObservableList} exposed: mutating the result no longer affects the document. Each
+     * call is O(n), so hold the result rather than calling it per item in a loop.</p>
+     *
+     * @return list of {@link net.perspective.draw.geom.DrawItem} in z-order
      */
     public List<DrawItem> getDrawings() {
-        return list;
+        return store.getDrawItems();
     }
 
     /**
@@ -563,73 +670,130 @@ public class CanvasView {
         images.set(index, item);
     }
 
+// ---------------------------------------------------------------------------
+// Mutation
+// ---------------------------------------------------------------------------
+
     /**
      * Set selection exclusively, clearing any prior multi-selection.
      *
-     * @param selection selected index
+     * @param id the slot id, or null to clear
      */
-    public void resetSelected(int selection) {
-        selectionIndex.clear();
-        setSelected(selection);
+    public void resetSelectedId(ItemId id) {
+        selectionIds.clear();
+        setSelectedId(id);
     }
 
     /**
-     * Return the first selected item
+     * Add a DrawItem to the selection.
      *
-     * @param selection selected index
+     * @param id the slot id, or null to clear
+     */
+    public void setSelectedId(ItemId id) {
+        if (id == null) {
+            selectionIds.clear();
+            return;
+        }
+        if (!drawarea.isMultiSelectEnabled()) {
+            selectionIds.clear();
+        }
+        selectionIds.add(id);
+    }
+
+    /**
+     * Add a DrawItem to the selection by index.
+     *
+     * <p>Compatibility shim for call sites not yet migrated. Resolves the index against the
+     * current snapshot immediately, so the stored id is stable even though the index was not.
+     * Prefer {@link #setSelectedId} where an id is already to hand.</p>
+     *
+     * @param selection the index, or -1 to clear
      */
     public void setSelected(int selection) {
+        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         if (selection == -1) {
-            ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
             nodes.remove(drawingAnchors);
             nodes.remove(highlight);
             nodes.remove(itemPivot);
-            selectionIndex.clear();
+            selectionIds.clear();
             drawingAnchors.getChildren().clear();
             itemPivot.getChildren().clear();
-        } else {
-            ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
-            nodes.remove(drawingAnchors);
-            nodes.remove(highlight);
-            nodes.remove(itemPivot);
-            if (!drawarea.isMultiSelectEnabled()) {
-                selectionIndex.clear();
-                drawingAnchors.getChildren().clear();
-            }
-            selectionIndex.add(selection);
-            drawingAnchors = getAnchors();
-            nodes.add(drawingAnchors);
-            if (drawarea.isRotationMode()) {
-                itemPivot = g2.drawRotationPivot(drawings.get(selection));
-                nodes.add(itemPivot);
-            }
-            setTextHighlight(selection);
+            return;
         }
+        Snapshot snap = store.snapshot();
+        if (selection < 0 || selection >= snap.size()) {
+            return;                                  // stale index; leave selection untouched
+        }
+        nodes.remove(drawingAnchors);
+        nodes.remove(highlight);
+        nodes.remove(itemPivot);
+        if (!drawarea.isMultiSelectEnabled()) {
+            selectionIds.clear();
+            drawingAnchors.getChildren().clear();
+        }
+        setSelectedId(snap.order().get(selection));  // must precede getAnchors(), which reads the selection
+        drawingAnchors = getAnchors(snap);
+        nodes.add(drawingAnchors);
+        if (drawarea.isRotationMode()) {
+            itemPivot = g2.drawRotationPivot(snap.at(selection));
+            nodes.add(itemPivot);
+        }
+        setTextHighlight(selection);
+    }
+
+    /**
+     * Remove an item from the selection.
+     *
+     * @param id the slot id
+     * @return true if it was selected
+     */
+    public boolean deselect(ItemId id) {
+        return selectionIds.remove(id);
+    }
+
+    /**
+     * Drop selected ids whose items no longer exist.
+     *
+     * <p>Call after a remote delete, or anywhere a stale selection would be visible to the user.
+     * Not called automatically: the accessors already skip missing items, so pruning is about
+     * keeping {@link #isMultiSelected()} and the size honest rather than about safety.</p>
+     *
+     * @return the number of ids dropped
+     */
+    public int pruneSelection() {
+        Snapshot snap = store.snapshot();
+        int before = selectionIds.size();
+        selectionIds.removeIf(id -> snap.get(id) == null);
+        return before - selectionIds.size();
     }
 
     /**
      * Move the selection and update drawing anchors
-     * 
+     *
      * @param selection selected index
      */
     public void moveSelection(int selection) {
+        ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         if (!drawingAnchors.getChildren().isEmpty()) {
-            ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
             nodes.remove(drawingAnchors);
             nodes.remove(highlight);
             nodes.remove(itemPivot);
             drawingAnchors.getChildren().clear();
         }
-        if (selection != -1) {
-            ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
-            drawingAnchors = getAnchors();
-            nodes.add(drawingAnchors);
-            if (drawarea.isRotationMode()) {
-                itemPivot = g2.drawRotationPivot(drawings.get(selection));
-                nodes.add(itemPivot);
-            }
-            setTextHighlight(selection);
+        if (selection == -1) {
+            return;
         }
+        Snapshot snap = store.snapshot();
+        if (selection < 0 || selection >= snap.size()) {
+            return;                                  // stale index; anchors already cleared
+        }
+        drawingAnchors = getAnchors(snap);
+        nodes.add(drawingAnchors);
+        if (drawarea.isRotationMode()) {
+            itemPivot = g2.drawRotationPivot(snap.at(selection));
+            nodes.add(itemPivot);
+        }
+        setTextHighlight(selection);
     }
 
     /**
@@ -641,7 +805,11 @@ public class CanvasView {
         ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
         nodes.remove(highlight);
         if (isEditing()) {
-            highlight = g2.highlightText(drawings.get(selection));
+            DrawItem item = store.lookupId(selection);
+            if (item == null) {
+                return;                              // stale index; caret simply not drawn
+            }
+            highlight = g2.highlightText(item);
             if (textController.getEditor().getCaretStart() == textController.getEditor().getCaretEnd()) {
                 caretTimeline.play();
             } else {
@@ -653,73 +821,156 @@ public class CanvasView {
 
     /**
      * Define the drawing anchors
-     * 
+     *
+     * <p>Reads the selection, so any id must already be registered before this is called.
+     * Ids whose items have been removed are skipped rather than throwing — a stale member
+     * simply contributes no anchor.</p>
+     *
+     * @param snap the store snapshot to resolve ids against
      * @return anchor {@link javafx.scene.Group}
      */
-    private Group getAnchors() {
+    private Group getAnchors(Snapshot snap) {
         Group anchorGroup = new Group();
-        for (Integer item : selectionIndex) {
-            anchorGroup.getChildren().add(drawings.get(item).drawAnchors(drawarea));
+        for (ItemId id : selectionIds) {
+            DrawItem item = snap.get(id);
+            if (item != null) {
+                anchorGroup.getChildren().add(item.drawAnchors(drawarea));
+            }
         }
         return anchorGroup;
     }
 
+// ---------------------------------------------------------------------------
+// Access
+// ---------------------------------------------------------------------------
+
     /**
-     * Return the first selected item
-     * 
-     * @return index
+     * The primary selected item.
+     *
+     * @return the slot id, or null if nothing is selected
+     */
+    public ItemId getSelectedId() {
+        if (selectionIds.isEmpty()) {
+            return null;
+        }
+        return selectionIds.iterator().next();    // insertion order
+    }
+
+    /**
+     * The primary selected item, as an index.
+     *
+     * <p>Compatibility shim. Returns -1 when nothing is selected <em>or</em> when the selected
+     * item has been removed — callers cannot distinguish, which is the same contract as before.</p>
+     *
+     * <p>Each call is an O(n) scan of the z-order. That is fine for event handling but not inside
+     * a loop: for a pass over many items, take one {@link Snapshot} and use
+     * {@code snap.indexOf(id)}, or work in ids and skip the conversion.</p>
+     *
+     * @return index of the DrawItem, or -1
      */
     public int getSelected() {
-        int i;
-        if (!selectionIndex.isEmpty()) {
-            Integer[] a = selectionIndex.toArray(Integer[]::new);
-            // find first value
-            i = a[0];
-        } else {
-            i = -1;
-        }
-        return i;
+        ItemId id = getSelectedId();
+        return id == null ? -1 : store.indexOf(id);
     }
 
     /**
-     * Return the selection with the lowest index in the 
-     * drawing list
-     * 
-     * @return index
+     * Lowest member of the multi-selection in z-order.
+     *
+     * @return the id, or null if the selection is empty or fully stale
      */
-    public int getBottomSelected() {
-        int i;
-        if (!selectionIndex.isEmpty()) {
-            Integer[] a = selectionIndex.toArray(Integer[]::new);
-            // find minimum value
-            i = a[0];
-            for (Integer as : a) {
-                if (as < i) {
-                    i = as;
-                }
+    public ItemId getBottomSelectedId() {
+        Snapshot snap = store.snapshot();
+        ItemId bottom = null;
+        int bottomIndex = Integer.MAX_VALUE;
+        for (ItemId id : selectionIds) {
+            int index = snap.indexOf(id);
+            if (index != -1 && index < bottomIndex) {
+                bottomIndex = index;
+                bottom = id;
             }
-        } else {
-            i = -1;
         }
-        return i;
+        return bottom;
     }
 
     /**
-     * Get the selection
-     * 
-     * @return set of selected indices
+     * The selection.
+     *
+     * <p>Unmodifiable: the original returned the live Set, letting callers mutate selection state
+     * behind this class's back. May contain ids whose items have been removed —
+     * {@link #getSelectionInZOrder()} or {@code store.lookupAll} filter those.</p>
+     *
+     * @return the selected slot ids, in insertion order
      */
-    public Set<Integer> getMultiSelection() {
-        return selectionIndex;
+    public Set<ItemId> getMultiSelection() {
+        return Collections.unmodifiableSet(selectionIds);
     }
 
     /**
-     * Are multiple items selected
-     * 
-     * @return multi-select active
+     * The selection sorted by z-order, with removed items dropped.
+     *
+     * <p>Use this wherever stacking matters — grouping in particular, since {@code Grouped} takes
+     * members in the order given, and {@link #selectionIds} is in click order.</p>
+     *
+     * @return the selected slot ids, bottom first
+     */
+    public List<ItemId> getSelectionInZOrder() {
+        return getSelectionInZOrder(store.snapshot());
+    }
+
+    /**
+     * The selection sorted by z-order, resolved against a snapshot the caller already holds.
+     *
+     * <p>Walks the z-order and keeps the selected ids, rather than sorting the selection by
+     * {@code indexOf}: one pass with a hash lookup per item, and stale ids fall out for free
+     * because they are not in {@code snap.order()}.</p>
+     *
+     * @param snap the store snapshot to resolve ids against
+     * @return the selected slot ids, bottom first
+     */
+    private List<ItemId> getSelectionInZOrder(Snapshot snap) {
+        List<ItemId> live = new ArrayList<>(selectionIds.size());
+        for (ItemId id : snap.order()) {
+            if (selectionIds.contains(id)) {
+                live.add(id);
+            }
+        }
+        return live;
+    }
+
+    /**
+     * The selected items.
+     *
+     * @return the {@link DrawItem}s, skipping any removed
+     */
+    public List<DrawItem> getSelectedDrawItems() {
+        return store.lookupAll(selectionIds);
+    }
+
+    /**
+     * @param id the slot id
+     * @return true if selected
+     */
+    public boolean isSelected(ItemId id) {
+        return selectionIds.contains(id);
+    }
+
+    /**
+     * Are multiple items selected.
+     *
+     * <p>Counts held ids, including any whose items have been removed. Call
+     * {@link #pruneSelection()} first if that distinction matters.</p>
+     *
+     * @return true if more than one DrawItem is selected
      */
     public boolean isMultiSelected() {
-        return selectionIndex.size() > 1;
+        return selectionIds.size() > 1;
+    }
+
+    /**
+     * @return true if nothing is selected
+     */
+    public boolean hasNoSelection() {
+        return selectionIds.isEmpty();
     }
 
     /**
@@ -730,10 +981,15 @@ public class CanvasView {
     public void selectShapes(DrawItem item) {
         Shape b = item.bounds();
         Rectangle2D boundary = b.getBounds2D();
-        for (DrawItem drawing : drawings) {
+        Snapshot snap = store.snapshot();
+        for (ItemId id : snap.order()) {
+            DrawItem drawing = snap.get(id);
+            if (drawing == null) {
+                continue;
+            }
             Rectangle2D d = drawing.bounds().getBounds2D();
             if (boundary.contains(d)) {
-                this.setSelected(drawings.indexOf(drawing));
+                this.setSelectedId(id);
             }
         }
     }
@@ -878,6 +1134,7 @@ public class CanvasView {
             ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
             nodes.remove(drawGuides);
             drawGuides = drawarea.getGuides().draw();
+            drawGuides.setId(GUIDES_ID);             // leading chrome; see itemBase()
             nodes.add(0, drawGuides);
         } else {
             ObservableList<Node> nodes = drawarea.getCanvas().getChildren();
@@ -906,7 +1163,7 @@ public class CanvasView {
         CanvasPoint start = new CanvasPoint();
         CanvasPoint end = new CanvasPoint();
 
-        for (DrawItem shape : list) {
+        for (DrawItem shape : store.getDrawItems()) {
             points.add(shape.getTop()[0]);
             points.add(shape.getBottom()[0]);
             points.add(shape.getUp()[0]);

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -261,11 +261,35 @@ public class CanvasView {
 
     /**
      * Add item to canvas
-     * 
+     *
      * @param item the {@link net.perspective.draw.geom.DrawItem}
      */
     public void appendItemToCanvas(DrawItem item) {
         store.append(item);
+    }
+
+    /**
+     * Replace the document with the contents of a file.
+     *
+     * <p>Images are installed before the items, and this ordering is required rather than tidy: a
+     * {@link net.perspective.draw.geom.Picture} renders by resolving its image index against that
+     * list, so an item published ahead of its bitmap has nothing to draw.</p>
+     *
+     * <p>The selection is dropped because {@link ItemStore#load} mints fresh ids, leaving every id
+     * held from before the load — the selection above all — pointing at nothing. Cleared here so a
+     * caller cannot forget.</p>
+     *
+     * <p>One publication for the whole document. Appending item by item instead rebuilds the
+     * snapshot per item, which is O(n²) over a load, and asks the binder to reconcile n times.</p>
+     *
+     * @param items the {@link net.perspective.draw.geom.DrawItem}s in z-order
+     * @param pictures the {@link net.perspective.draw.ImageItem}s in saved order
+     */
+    public void loadItemsToCanvas(List<DrawItem> items, List<ImageItem> pictures) {
+        this.setSelected(-1);
+        images.clear();
+        images.addAll(pictures);
+        store.load(items);
     }
 
     /**

--- a/src/main/java/net/perspective/draw/CanvasView.java
+++ b/src/main/java/net/perspective/draw/CanvasView.java
@@ -1252,13 +1252,27 @@ public class CanvasView {
      * @return bounding {@link net.perspective.draw.util.CanvasPoint}
      */
     public CanvasPoint[] getBounds() {
+        return getBounds(store.getDrawItems());
+    }
+
+    /**
+     * Helper method used by export routines
+     *
+     * <p>Takes the items to measure rather than reading the store, so an exporter can size its
+     * output and render its content from one capture. Reading the store twice lets the document
+     * change in between, giving a canvas sized for one set of items and drawn from another.</p>
+     *
+     * @param items the {@link net.perspective.draw.geom.DrawItem}s to measure
+     * @return bounding {@link net.perspective.draw.util.CanvasPoint}
+     */
+    public CanvasPoint[] getBounds(List<DrawItem> items) {
         CanvasPoint topleft, bottomright;
 
         List<CanvasPoint> points = new ArrayList<>();
         CanvasPoint start = new CanvasPoint();
         CanvasPoint end = new CanvasPoint();
 
-        for (DrawItem shape : store.getDrawItems()) {
+        for (DrawItem shape : items) {
             points.add(shape.getTop()[0]);
             points.add(shape.getBottom()[0]);
             points.add(shape.getUp()[0]);

--- a/src/main/java/net/perspective/draw/DrawAppComponent.java
+++ b/src/main/java/net/perspective/draw/DrawAppComponent.java
@@ -197,6 +197,8 @@ public interface DrawAppComponent {
     Picture picture();
 
     StreetMap streetMap();
+    
+    ItemStore itemStore();
 
     @Component.Builder
     interface Builder {

--- a/src/main/java/net/perspective/draw/DrawingArea.java
+++ b/src/main/java/net/perspective/draw/DrawingArea.java
@@ -81,6 +81,7 @@ public class DrawingArea {
     @Inject Dropper dropper;
     @Inject MapController mapper;
     @Inject G2 g2;
+    @Inject ItemStore store;
     @Inject BehaviourContext context;
     private SubScene canvas;
     private Group root;
@@ -580,12 +581,11 @@ public class DrawingArea {
      * Initiate map edit mode
      */
     protected void editMapItem() {
-        if (viewProvider.get().getSelected() != -1) {
-            DrawItem item = viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
-            if (item instanceof StreetMap) {
-                context.setBehaviour(mapItemBehaviourProvider.get());
-                context.edit(item, viewProvider.get().getSelected());
-            }
+        ItemId id = viewProvider.get().getSelectedId();
+        DrawItem item = store.lookupId(id);
+        if (item instanceof StreetMap) {
+            context.setBehaviour(mapItemBehaviourProvider.get());
+            context.edit(item, id);
         }
     }
 
@@ -593,15 +593,14 @@ public class DrawingArea {
      * Initiate text edit mode
      */
     protected void editTextItem() {
-        if (viewProvider.get().getSelected() != -1) {
-            DrawItem item = viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
-            if (item instanceof Text text) {
-                context.setBehaviour(textItemBehaviourProvider.get());
-                context.edit(text, viewProvider.get().getSelected());
-                text.setDimensions();
-                viewProvider.get().updateSelectedItem();
-                viewProvider.get().moveSelection(viewProvider.get().getSelected());
-            }
+        ItemId id = viewProvider.get().getSelectedId();
+        DrawItem item = store.lookupId(id);
+        if (item instanceof Text text) {
+            context.setBehaviour(textItemBehaviourProvider.get());
+            context.edit(text, id);
+            text.setDimensions();
+            viewProvider.get().updateSelectedItem();
+            viewProvider.get().moveSelection(id);
         }
     }
 

--- a/src/main/java/net/perspective/draw/DrawingArea.java
+++ b/src/main/java/net/perspective/draw/DrawingArea.java
@@ -198,26 +198,26 @@ public class DrawingArea {
         });
         controller.getFontFamilyProperty().addListener((ObservableValue<? extends String> observable, String oldValue, String newValue) -> {
             this.setFontFamily(newValue);
-            viewProvider.get().moveSelection(viewProvider.get().getSelected());
+            viewProvider.get().refreshSelection();
         });
         controller.getFontSizeProperty().addListener((ObservableValue<? extends String> observable, String oldValue, String newValue) -> {
             this.setFontSize(Integer.parseInt(newValue));
-            viewProvider.get().moveSelection(viewProvider.get().getSelected());
+            viewProvider.get().refreshSelection();
         });
         controller.getBoldProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) -> {
             textControllerProvider.get().formatSelectedText(newValue, TextFormatter.FONT_BOLD);
             viewProvider.get().updateSelectedItem();
-            viewProvider.get().moveSelection(viewProvider.get().getSelected());
+            viewProvider.get().refreshSelection();
         });
         controller.getItalicProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) -> {
             textControllerProvider.get().formatSelectedText(newValue, TextFormatter.FONT_ITALIC);
             viewProvider.get().updateSelectedItem();
-            viewProvider.get().moveSelection(viewProvider.get().getSelected());
+            viewProvider.get().refreshSelection();
         });
         controller.getUnderlinedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue) -> {
             textControllerProvider.get().formatSelectedText(newValue, TextFormatter.FONT_UNDERLINED);
             viewProvider.get().updateSelectedItem();
-            viewProvider.get().moveSelection(viewProvider.get().getSelected());
+            viewProvider.get().refreshSelection();
         });
     }
 
@@ -243,7 +243,7 @@ public class DrawingArea {
      */
     public void setTheme() {
         canvas.setFill(Color.web(controller.getCanvasBackgroundColor()));
-        viewProvider.get().moveSelection(viewProvider.get().getSelected());
+        viewProvider.get().refreshSelection();
     }
 
     /**
@@ -456,7 +456,7 @@ public class DrawingArea {
                 if (item instanceof Text) {
                     viewProvider.get().cutTextItem();
                     viewProvider.get().updateSelectedItem();
-                    viewProvider.get().moveSelection(viewProvider.get().getSelected());
+                    viewProvider.get().refreshSelection();
                 }
             }
         });
@@ -467,7 +467,7 @@ public class DrawingArea {
                 if (item instanceof Text) {
                     viewProvider.get().copyTextItem();
                     viewProvider.get().updateSelectedItem();
-                    viewProvider.get().moveSelection(viewProvider.get().getSelected());
+                    viewProvider.get().refreshSelection();
                 }
             }
         });
@@ -477,7 +477,7 @@ public class DrawingArea {
             if (item instanceof Text) {
                 viewProvider.get().pasteTextItem();
                 viewProvider.get().updateSelectedItem();
-                viewProvider.get().moveSelection(viewProvider.get().getSelected());
+                viewProvider.get().refreshSelection();
             }
         });
         // contextmenu.getItems().addAll(menuCut, menuCopy, menuPaste);

--- a/src/main/java/net/perspective/draw/DrawingArea.java
+++ b/src/main/java/net/perspective/draw/DrawingArea.java
@@ -400,10 +400,24 @@ public class DrawingArea {
     }
 
     /**
+     * May the selection be restructured — grouped, ungrouped or restacked.
+     *
+     * <p>The guard shared by the structural context-menu actions. Each needs an item selected and
+     * neither modal editor holding the canvas: reordering the z-order underneath a map or a text
+     * item being edited would leave that editor addressing the wrong thing.</p>
+     *
+     * @return true if a structural action may proceed
+     */
+    private boolean canRestructureSelection() {
+        CanvasView view = viewProvider.get();
+        return view.hasSelection() && !view.isMapping() && !view.isEditing();
+    }
+
+    /**
      * Cut the selected item
      */
     public void cutSelectedItem() {
-        if (viewProvider.get().getSelected() != -1) {
+        if (viewProvider.get().hasSelection()) {
             clipboard = transferhandler.createTransferable();
             transferhandler.exportDone(clipboard, MOVE);
             systemClipboard.setContents(clipboard, null);
@@ -415,7 +429,7 @@ public class DrawingArea {
      * Copy the selected item
      */
     public void copySelectedItem() {
-        if (viewProvider.get().getSelected() != -1) {
+        if (viewProvider.get().hasSelection()) {
             clipboard = transferhandler.createTransferable();
             transferhandler.exportDone(clipboard, COPY);
             systemClipboard.setContents(clipboard, null);
@@ -477,13 +491,13 @@ public class DrawingArea {
         SeparatorMenuItem groupSeparator = new SeparatorMenuItem();
         MenuItem menuGroup = new MenuItem("Group Selection");
         menuGroup.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().groupSelection();
             }
         });
         MenuItem menuUnGroup = new MenuItem("Ungroup Selection");
         menuUnGroup.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().ungroupSelection();
             }
         });
@@ -491,28 +505,28 @@ public class DrawingArea {
         SeparatorMenuItem sendSeparator = new SeparatorMenuItem();
         MenuItem menuSBItem = new MenuItem("Send Backwards");
         menuSBItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().sendBackwards();
                 viewProvider.get().setSelected(-1);
             }
         });
         MenuItem menuBFItem = new MenuItem("Bring Forwards");
         menuBFItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().bringForwards();
                 viewProvider.get().setSelected(-1);
             }
         });
         MenuItem menuSTBItem = new MenuItem("Send to Back");
         menuSTBItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().sendToBack();
                 viewProvider.get().setSelected(-1);
             }
         });
         MenuItem menuBTFItem = new MenuItem("Bring to Front");
         menuBTFItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+            if (canRestructureSelection()) {
                 viewProvider.get().bringToFront();
                 viewProvider.get().setSelected(-1);
             }
@@ -520,13 +534,13 @@ public class DrawingArea {
         // contextmenu.getItems().addAll(sendSeparator, menuSBItem, menuBFItem, menuSTBItem, menuBTFItem);
         MenuItem menuEditMapItem = new MenuItem("Edit");
         menuEditMapItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1) {
+            if (viewProvider.get().hasSelection()) {
                 editMapItem();
             }
         });
         MenuItem menuEditTextItem = new MenuItem("Edit");
         menuEditTextItem.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1) {
+            if (viewProvider.get().hasSelection()) {
                 editTextItem();
             }
         });

--- a/src/main/java/net/perspective/draw/DrawingArea.java
+++ b/src/main/java/net/perspective/draw/DrawingArea.java
@@ -451,30 +451,23 @@ public class DrawingArea {
         });
         MenuItem menuTextCut = new MenuItem("Cut");
         menuTextCut.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1) {
-                DrawItem item = viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
-                if (item instanceof Text) {
-                    viewProvider.get().cutTextItem();
-                    viewProvider.get().updateSelectedItem();
-                    viewProvider.get().refreshSelection();
-                }
+            if (viewProvider.get().getSelectedDrawItem() instanceof Text) {
+                viewProvider.get().cutTextItem();
+                viewProvider.get().updateSelectedItem();
+                viewProvider.get().refreshSelection();
             }
         });
         MenuItem menuTextCopy = new MenuItem("Copy");
         menuTextCopy.setOnAction((ActionEvent e) -> {
-            if (viewProvider.get().getSelected() != -1) {
-                DrawItem item = viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
-                if (item instanceof Text) {
-                    viewProvider.get().copyTextItem();
-                    viewProvider.get().updateSelectedItem();
-                    viewProvider.get().refreshSelection();
-                }
+            if (viewProvider.get().getSelectedDrawItem() instanceof Text) {
+                viewProvider.get().copyTextItem();
+                viewProvider.get().updateSelectedItem();
+                viewProvider.get().refreshSelection();
             }
         });
         MenuItem menuTextPaste = new MenuItem("Paste");
         menuTextPaste.setOnAction((ActionEvent e) -> {
-            DrawItem item = viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
-            if (item instanceof Text) {
+            if (viewProvider.get().getSelectedDrawItem() instanceof Text) {
                 viewProvider.get().pasteTextItem();
                 viewProvider.get().updateSelectedItem();
                 viewProvider.get().refreshSelection();
@@ -541,15 +534,16 @@ public class DrawingArea {
         SeparatorMenuItem editSeparator = new SeparatorMenuItem();
         contextlistener = (ContextMenuEvent event) -> {
             contextmenu.getItems().clear();
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
-                if (viewProvider.get().getDrawings().get(viewProvider.get().getSelected()) instanceof StreetMap) {
+            DrawItem selected = viewProvider.get().getSelectedDrawItem();
+            if (selected != null && !viewProvider.get().isMapping() && !viewProvider.get().isEditing()) {
+                if (selected instanceof StreetMap) {
                     contextmenu.getItems().addAll(menuEditMapItem, editSeparator);
-                } else if (viewProvider.get().getDrawings().get(viewProvider.get().getSelected()) instanceof Text) {
+                } else if (selected instanceof Text) {
                     contextmenu.getItems().addAll(menuEditTextItem, editSeparator);
                 }
             }
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && viewProvider.get().isEditing()) {
-                if (viewProvider.get().getDrawings().get(viewProvider.get().getSelected()) instanceof Text) {
+            if (selected != null && !viewProvider.get().isMapping() && viewProvider.get().isEditing()) {
+                if (selected instanceof Text) {
                     contextmenu.getItems().addAll(menuTextCut, menuTextCopy, menuTextPaste);
                 }
             } else {
@@ -561,7 +555,7 @@ public class DrawingArea {
         };
         popuplistener = (TouchEvent event) -> {
             contextmenu.getItems().clear();
-            if (viewProvider.get().getSelected() != -1 && !viewProvider.get().isMapping() && viewProvider.get().getDrawings().get(viewProvider.get().getSelected()) instanceof StreetMap) {
+            if (!viewProvider.get().isMapping() && viewProvider.get().getSelectedDrawItem() instanceof StreetMap) {
                 contextmenu.getItems().addAll(menuEditMapItem, editSeparator);
             }
             contextmenu.getItems().addAll(menuCut, menuCopy, menuPaste);

--- a/src/main/java/net/perspective/draw/FxSnapshotBinder.java
+++ b/src/main/java/net/perspective/draw/FxSnapshotBinder.java
@@ -1,0 +1,272 @@
+/**
+ * FxSnapshotBinder.java
+ * 
+ * Created on 26 Aug 2026 09:02:57
+ * 
+ */
+
+/**
+ * Copyright (c) 2026 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import net.perspective.draw.ItemStore.Snapshot;
+import net.perspective.draw.geom.DrawItem;
+
+/**
+ *
+ * @author claude
+ */
+
+/**
+ * Keeps an {@link ObservableList} in step with an {@link ItemStore}.
+ *
+ * <h2>Why reconcile rather than replay</h2>
+ * <p>An {@code ObservableList} may only be mutated on the FX Application Thread, while the store
+ * publishes from whichever thread performed the write. Notifications therefore have to be posted,
+ * and once they are posted a burst of publications must coalesce into a single pass or the FX
+ * thread drowns. A coalesced pass cannot replay individual deltas — it has to be able to go from
+ * whatever the list currently holds to whatever the newest snapshot holds. Hence reconciliation.</p>
+ *
+ * <h2>Why not setAll</h2>
+ * <p>{@code list.setAll(snapshot items)} is one line and correct, and is the right answer if the
+ * list only backs a {@code ListView} or similar. It is the wrong answer if each item maps to a
+ * {@code Node} in a scene graph: it fires a single change that replaces every element, so every
+ * node is discarded and rebuilt on every publication — including publications that changed one
+ * item. This class diffs by {@link ItemId} instead and emits only the changes that occurred.</p>
+ *
+ * <h2>Identity</h2>
+ * <p>Diffing works because ids are stable slot identities: {@code replaceItem} rebinds a slot's
+ * existing id and {@code move} repositions without changing it. A replaced item is detected as a
+ * <em>rebind</em> — same id, different instance — and refreshes just that entry, which is what
+ * lets an inbound sync replacement update one node rather than the whole graph.</p>
+ *
+ * <h2>Threading</h2>
+ * <p>{@link #attach()} and {@link #detach()} are called from the FX thread. Everything else is
+ * internal. The store notifies from inside its lock, so the listener does nothing but schedule.</p>
+ */
+
+@Singleton
+public class FxSnapshotBinder {
+
+    private final ItemStore store;
+
+    /** Z-order, mirrored for rendering. FX thread only. */
+    private final ObservableList<ItemId> order = FXCollections.observableArrayList();
+
+    /** Which instance each id is currently bound to, for rebind detection. FX thread only. */
+    private final Map<ItemId, DrawItem> bound = new HashMap<>();
+
+    /** Set when a pass is queued but has not yet started. */
+    private final AtomicBoolean scheduled = new AtomicBoolean();
+
+    /** Revision last applied to {@code order}. FX thread only. */
+    private long appliedRevision = -1L;
+
+    /** Notified per changed entry, for scene-graph maintenance. May be null. */
+    private ItemListener itemListener;
+
+    /**
+     * Notified about individual entries as the list is reconciled, so a scene graph can be kept in
+     * step without diffing the {@link ObservableList} a second time.
+     */
+    public interface ItemListener {
+
+        /**
+         * A new slot appeared.
+         *
+         * @param id    the slot id
+         * @param item  the item
+         * @param index its position in z-order
+         */
+        void added(ItemId id, DrawItem item, int index);
+
+        /**
+         * A slot's item was replaced — same id, different instance. The node for this id should be
+         * rebuilt or refreshed; it should not be recreated from scratch if refresh is cheaper.
+         *
+         * @param id   the slot id
+         * @param item the new item
+         */
+        void rebound(ItemId id, DrawItem item);
+
+        /**
+         * A slot was removed. Any node cached for this id should be discarded.
+         *
+         * @param id the slot id
+         */
+        void removed(ItemId id);
+
+        /** Z-order changed; nodes should be restacked to match. */
+        void reordered();
+    }
+
+    /**
+     * @param store the store to mirror
+     */
+    @Inject
+    public FxSnapshotBinder(ItemStore store) {
+        this.store = store;
+    }
+
+    /**
+     * The mirrored z-order. Read on the FX thread; do not mutate.
+     *
+     * @return the observable id list
+     */
+    public ObservableList<ItemId> getOrder() {
+        return order;
+    }
+
+    /**
+     * @param id the slot id
+     * @return the item currently bound to that id, or null
+     */
+    public DrawItem get(ItemId id) {
+        return bound.get(id);
+    }
+
+    /**
+     * @param itemListener notified per changed entry, or null
+     */
+    public void setItemListener(ItemListener itemListener) {
+        this.itemListener = itemListener;
+    }
+
+    /**
+     * Begin mirroring. Call on the FX thread.
+     */
+    public void attach() {
+        store.setListener(this::onPublished);
+        schedule();                                  // pick up whatever is already there
+    }
+
+    /**
+     * Stop mirroring. Call on the FX thread.
+     */
+    public void detach() {
+        store.setListener(null);
+    }
+
+    /**
+     * Called from the store, inside its lock, on whatever thread wrote. Does nothing but schedule.
+     *
+     * @param revision the revision published
+     */
+    private void onPublished(long revision) {
+        schedule();
+    }
+
+    private void schedule() {
+        if (scheduled.compareAndSet(false, true)) {
+            Platform.runLater(this::reconcile);
+        }
+    }
+
+    /**
+     * Bring the mirrored list up to the newest snapshot. FX thread only.
+     */
+    private void reconcile() {
+        /*
+         * Clear the flag BEFORE reading the snapshot. A publication arriving during reconciliation
+         * then schedules a further pass, rather than being swallowed because the flag was still
+         * set while we worked.
+         */
+        scheduled.set(false);
+
+        Snapshot snap = store.snapshot();            // always the newest, never a queued one
+        if (snap.revision() == appliedRevision) {
+            return;                                  // coalesced away
+        }
+
+        List<ItemId> target = snap.order();
+        boolean structural = false;
+
+        // 1. Removals, as one change event.
+        Set<ItemId> live = new HashSet<>(target);
+        List<ItemId> gone = new ArrayList<>();
+        for (ItemId id : order) {
+            if (!live.contains(id)) {
+                gone.add(id);
+            }
+        }
+        if (!gone.isEmpty()) {
+            order.removeAll(gone);
+            for (ItemId id : gone) {
+                bound.remove(id);
+                if (itemListener != null) {
+                    itemListener.removed(id);
+                }
+            }
+            structural = true;
+        }
+
+        // 2. Insertions and reordering, walking to match target position by position.
+        for (int i = 0; i < target.size(); i++) {
+            ItemId id = target.get(i);
+            if (i < order.size() && order.get(i).equals(id)) {
+                continue;
+            }
+            int at = order.indexOf(id);
+            if (at == -1) {
+                order.add(i, id);
+                DrawItem item = snap.get(id);
+                bound.put(id, item);
+                if (itemListener != null) {
+                    itemListener.added(id, item, i);
+                }
+            } else {
+                order.remove(at);                    // moved
+                order.add(i, id);
+            }
+            structural = true;
+        }
+
+        // 3. Rebinds: same slot, different instance.
+        for (ItemId id : target) {
+            DrawItem current = snap.get(id);
+            if (current == null) {
+                continue;
+            }
+            DrawItem previous = bound.get(id);
+            if (previous != current) {               // identity, not equals
+                bound.put(id, current);
+                if (itemListener != null && previous != null) {
+                    itemListener.rebound(id, current);
+                }
+            }
+        }
+
+        if (structural && itemListener != null) {
+            itemListener.reordered();
+        }
+
+        appliedRevision = snap.revision();
+    }
+
+}

--- a/src/main/java/net/perspective/draw/FxSnapshotBinder.java
+++ b/src/main/java/net/perspective/draw/FxSnapshotBinder.java
@@ -199,8 +199,15 @@ public class FxSnapshotBinder {
          */
         scheduled.set(false);
 
+        /*
+         * Drain before reading the snapshot — see ItemStore.drainDirty(). An id taken here is
+         * guaranteed to be at least as new in the snapshot read next; a write landing in the gap
+         * is not drained, and its own publication has already rescheduled this pass.
+         */
+        Set<ItemId> dirty = store.drainDirty();
+
         Snapshot snap = store.snapshot();            // always the newest, never a queued one
-        if (snap.revision() == appliedRevision) {
+        if (snap.revision() == appliedRevision && dirty.isEmpty()) {
             return;                                  // coalesced away
         }
 
@@ -247,16 +254,28 @@ public class FxSnapshotBinder {
             structural = true;
         }
 
-        // 3. Rebinds: same slot, different instance.
+        /*
+         * 3. Refreshes.
+         *
+         * Two ways a slot's content can change without its position changing. The sync layer
+         * supplies a replacement instance, which shows up as a different identity. The EDT edits
+         * the published item in place and republishes it, which shows up as nothing at all —
+         * dragging out a new figure does exactly this, mutating one instance from mouse-down to
+         * mouse-up — so that case is driven by the store's dirty set rather than by comparison.
+         */
         for (ItemId id : target) {
             DrawItem current = snap.get(id);
             if (current == null) {
                 continue;
             }
             DrawItem previous = bound.get(id);
-            if (previous != current) {               // identity, not equals
+            if (previous == null) {
+                bound.put(id, current);              // just added above; already rendered
+                continue;
+            }
+            if (previous != current || dirty.contains(id)) {
                 bound.put(id, current);
-                if (itemListener != null && previous != null) {
+                if (itemListener != null) {
                     itemListener.rebound(id, current);
                 }
             }

--- a/src/main/java/net/perspective/draw/ItemId.java
+++ b/src/main/java/net/perspective/draw/ItemId.java
@@ -1,0 +1,79 @@
+/*
+ * ItemId.java
+ * 
+ * Created on 26 Aug 2026 08:35:02
+ * 
+ */
+
+ /*
+ * Copyright (c) 2026 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ *
+ * @author ctipper
+ */
+
+public record ItemId(UUID id) {
+
+    public ItemId {
+        Objects.requireNonNull(id, "id");
+    }
+
+    public static ItemId freshId() {
+        return new ItemId(UUID.randomUUID());
+    }
+
+    public static ItemId parse(String s) {
+        return new ItemId(UUID.fromString(s));   // throws IllegalArgumentException if malformed
+    }
+
+    /** Parses the compact (22-char base64url) form produced by toCompact(). */
+    public static ItemId parseCompact(String s) {
+        Objects.requireNonNull(s, "s");
+        byte[] bytes;
+        try {
+            bytes = Base64.getUrlDecoder().decode(s);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid compact UUID: " + s, e);
+        }
+        if (bytes.length != 16) {
+            throw new IllegalArgumentException("Invalid compact UUID length: " + s);
+        }
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        long msb = bb.getLong();
+        long lsb = bb.getLong();
+        return new ItemId(new UUID(msb, lsb));
+    }
+
+    /** Compact 22-char base64url encoding — use for URLs, short display, etc. */
+    public String toCompact() {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(id.getMostSignificantBits());
+        bb.putLong(id.getLeastSignificantBits());
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array());
+    }
+
+    @Override
+    public String toString() { return id.toString(); }
+
+}

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -72,8 +72,7 @@ import net.perspective.draw.geom.DrawItem;
  *
  * <p>Because ids are minted per session, they are meaningless to other peers and must not be sent
  * on the wire or written to a file. The sync layer continues to address items by index; resolve
- * ids to indices at that boundary only, via {@link #indexOf} or {@link #indicesOf}, from a single
- * snapshot.</p>
+ * ids to indices at that boundary only, via {@link #indexOf}, from a single snapshot.</p>
  *
  * <h2>Item mutability contract</h2>
  * <p>The snapshot freezes <em>which</em> items exist and in what order. It does not freeze the
@@ -390,26 +389,7 @@ public class ItemStore {
         return snapshot.indexOf(id);
     }
 
-    /**
-     * Resolve ids to indices against a single snapshot, skipping any no longer present.
-     *
-     * @param ids item ids
-     * @return the indices, ascending
-     */
-    public List<Integer> indicesOf(Collection<ItemId> ids) {
-        Snapshot snap = snapshot;
-        List<Integer> out = new ArrayList<>(ids.size());
-        for (ItemId id : ids) {
-            int index = snap.indexOf(id);
-            if (index != -1) {
-                out.add(index);
-            }
-        }
-        out.sort(null);
-        return out;
-    }
-
-    // -----------------------------------------------------------------------
+        // -----------------------------------------------------------------------
     // Mutators
     // -----------------------------------------------------------------------
 
@@ -425,19 +405,21 @@ public class ItemStore {
     /**
      * Append item to the end of the z-order.
      *
+     * <p>Returns the slot id rather than the index it landed at: the index is only true until the
+     * next mutation, whereas the id keeps naming this item.</p>
+     *
      * @param item the {@link DrawItem}
-     * @return the index at which the item was placed
+     * @return the id of the slot the item was placed in
      */
-    public int append(DrawItem item) {
+    public ItemId append(DrawItem item) {
         lock.lock();
         try {
             ItemId id = mint();
             itemsById.put(id, item);
             items.add(id);
-            int index = items.size() - 1;
-            logger.debug("Create: Appended item at Index: {}", index);
+            logger.debug("Create: Appended item at Index: {}", items.size() - 1);
             publish();
-            return index;
+            return id;
         } finally {
             lock.unlock();
         }
@@ -818,20 +800,7 @@ public class ItemStore {
         return snapshot.revision();
     }
 
-    /**
-     * Capture the document for saving on the EDT.
-     *
-     * <p>Safe when the serialization itself also runs on the EDT. For a background writer use
-     * {@link #saveState()} instead — this method's list is stable but its <em>items</em> are live
-     * references the EDT may still mutate.</p>
-     *
-     * @return the items in z-order
-     */
-    public List<DrawItem> save() {
-        return getDrawItems();
-    }
-
-    /**
+        /**
      * Capture the document together with the revision it was taken at, for a background writer.
      *
      * <p>The capture fixes the set and ordering of items, but not the items themselves: the EDT

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -1,0 +1,871 @@
+/**
+ * ItemStore.java
+ * 
+ * Created on 26 Aug 2026 08:35:57
+ * 
+ */
+
+/**
+ * Copyright (c) 2026 Christopher Tipper
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.perspective.draw;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.swing.SwingUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.perspective.draw.geom.DrawItem;
+
+/**
+ *
+ * @author claude
+ */
+
+/**
+ * Thread-safe store for canvas items.
+ *
+ * <p>Authoritative state ({@code items}, {@code itemsById}, {@code removed}) is guarded by
+ * {@code lock} and is never exposed. Readers — principally the EDT paint path — see only the
+ * immutable {@link Snapshot} published to the volatile {@code snapshot} field, and therefore
+ * never take a lock. This matters: the EDT must not block on a mutation performed by the sync
+ * thread, and a lock shared between the two would risk deadlock if any write path ever calls
+ * back onto the EDT.</p>
+ *
+ * <h2>Threading contract</h2>
+ * <ul>
+ *   <li>All mutators may be called from any thread.</li>
+ *   <li>{@link #snapshot()} is lock-free and may be called from any thread, including the EDT.</li>
+ *   <li>A reader must take <em>one</em> snapshot per pass and use it for the whole pass. Calling
+ *       {@code snapshot()} repeatedly within a single paint, hit-test or group operation yields a
+ *       torn view.</li>
+ * </ul>
+ *
+ * <h2>Identity</h2>
+ * <p>{@link ItemId}s are minted by this class. {@link DrawItem} does not carry one and the
+ * serialized format does not persist one — identity is a store concern, not part of the object
+ * model. An id names a <em>slot</em> in the document, not an instance: {@link #replaceItem} keeps
+ * the slot's existing id and rebinds it to the new instance, so an id stays valid when the sync
+ * layer supplies a deserialized replacement. Selection, multi-selection and group membership are
+ * therefore safe to hold as ids.</p>
+ *
+ * <p>Because ids are minted per session, they are meaningless to other peers and must not be sent
+ * on the wire or written to a file. The sync layer continues to address items by index; resolve
+ * ids to indices at that boundary only, via {@link #indexOf} or {@link #indicesOf}, from a single
+ * snapshot.</p>
+ *
+ * <h2>Item mutability contract</h2>
+ * <p>The snapshot freezes <em>which</em> items exist and in what order. It does not freeze the
+ * items themselves. In-place mutation of a published {@link DrawItem} is permitted <strong>only
+ * from the EDT</strong>, because the paint pass is also an EDT task and the two cannot interleave.
+ * The sync thread must never mutate an item in place; it supplies freshly deserialized
+ * replacement instances via {@link #replaceItem}. If painting is ever moved off the EDT, or the
+ * sync thread ever begins applying field-level updates to existing items, this contract breaks
+ * and items must become effectively immutable.</p>
+ *
+ * <p>Note that background serialization reads items off the EDT and is therefore <em>not</em>
+ * covered by that contract — see {@link #saveState()}.</p>
+ */
+
+@Singleton
+public class ItemStore {
+
+    /** Creates a new instance of <code>ItemStore</code> */
+    @Inject
+    public ItemStore() {
+    }
+
+    /**
+     * An immutable point-in-time view of the store.
+     *
+     * @param order    item ids in z-order
+     * @param byId     item lookup
+     * @param revision monotonically increasing publication counter
+     */
+    public record Snapshot(List<ItemId> order, Map<ItemId, DrawItem> byId, long revision) {
+
+        /**
+         * @param i index into z-order
+         * @return the item at that index
+         */
+        public DrawItem at(int i) {
+            return byId.get(order.get(i));
+        }
+
+        /**
+         * @param id item id
+         * @return the item, or null if not present
+         */
+        public DrawItem get(ItemId id) {
+            // Null-safe for the same reason as indexOf: the map is immutable and get(null) throws.
+            return id == null ? null : byId.get(id);
+        }
+
+        /**
+         * @param id item id
+         * @return index in z-order, or -1 if not present
+         */
+        public int indexOf(ItemId id) {
+            /*
+             * Null-safe: the order list is immutable, and ImmutableCollections.indexOf throws
+             * on a null argument. A null id means "nothing selected", which is -1, not a fault.
+             */
+            return id == null ? -1 : order.indexOf(id);
+        }
+
+        /** @return number of items */
+        public int size() {
+            return order.size();
+        }
+
+        /** @return true if there are no items */
+        public boolean isEmpty() {
+            return order.isEmpty();
+        }
+    }
+
+    /**
+     * A point-in-time capture of the document for serialization.
+     *
+     * @param items    the items in z-order
+     * @param revision the store revision this was taken at
+     */
+    public record SaveState(List<DrawItem> items, long revision) {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ItemStore.class.getName());
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /** Z-ordered item ids. Guarded by {@code lock}. */
+    private final List<ItemId> items = new ArrayList<>();
+
+    /** Item lookup. Guarded by {@code lock}. */
+    private final Map<ItemId, DrawItem> itemsById = new HashMap<>();
+
+    /** Tombstones awaiting commit by {@link #removeItems()}. Guarded by {@code lock}. */
+    private final Set<ItemId> removed = new LinkedHashSet<>();
+
+    private long revision;
+    private int batchDepth;
+
+    /** The published view. Volatile: written under lock, read without. */
+    private volatile Snapshot snapshot = new Snapshot(List.of(), Map.of(), 0L);
+
+    /** Invoked after each publication, on the EDT. May be null. */
+    private Runnable repaintCallback;
+
+    /**
+     * Notified after each publication.
+     *
+     * <p>Called while the store lock is held, so an implementation must not block, must not call
+     * back into the store, and must not do work — it should post to a UI thread and return. The
+     * revision identifies the publication; the listener is expected to read
+     * {@link #snapshot()} itself when it runs, so that coalesced notifications converge on the
+     * latest state rather than replaying intermediate ones.</p>
+     */
+    @FunctionalInterface
+    public interface SnapshotListener {
+
+        /**
+         * @param revision the revision just published
+         */
+        void published(long revision);
+    }
+
+    /** Notified after each publication. May be null. */
+    private volatile SnapshotListener listener;
+
+    /**
+     * Set the listener notified after each publication.
+     *
+     * <p>Swing: {@code store.setListener(r -> SwingUtilities.invokeLater(canvas::repaint))}.
+     * JavaFX: see {@code FxSnapshotBinder}.</p>
+     *
+     * @param listener the listener, or null to disable
+     */
+    public void setListener(SnapshotListener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * Set the callback invoked on the EDT after each publication.
+     *
+     * @param repaintCallback typically {@code canvas::repaint}, or null to disable
+     */
+    public void setRepaintCallback(Runnable repaintCallback) {
+        this.repaintCallback = repaintCallback;
+    }
+
+    /**
+     * Lock-free. Safe to call from the EDT.
+     *
+     * @return the current published view
+     */
+    public Snapshot snapshot() {
+        return snapshot;
+    }
+
+    // -----------------------------------------------------------------------
+    // Read accessors
+    //
+    // Each of these takes exactly one snapshot internally, so a single call is
+    // always self-consistent. For a multi-step pass — hit-testing, grouping,
+    // painting, anything that walks the z-order — call snapshot() once and work
+    // against that instead, or successive calls here may see different states.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Z-ordered item ids from the current snapshot.
+     *
+     * <p>The returned list is immutable and safe to hand out; it is a published copy, not the
+     * lock-guarded field.</p>
+     *
+     * @return the item ids in z-order
+     */
+    public List<ItemId> getItems() {
+        return snapshot.order();
+    }
+
+    /**
+     * Items in z-order from the current snapshot.
+     *
+     * @return the items in z-order
+     */
+    public List<DrawItem> getDrawItems() {
+        Snapshot snap = snapshot;
+        List<DrawItem> out = new ArrayList<>(snap.size());
+        for (ItemId id : snap.order()) {
+            DrawItem item = snap.byId().get(id);
+            if (item != null) {
+                out.add(item);
+            }
+        }
+        return out;
+    }
+
+    /** @return the number of items in the current snapshot */
+    public int size() {
+        return snapshot.size();
+    }
+
+    /** @return true if the document is empty */
+    public boolean isEmpty() {
+        return snapshot.isEmpty();
+    }
+
+    /**
+     * Resolve an index against the current snapshot.
+     *
+     * <p>Returns null rather than throwing when the index is out of range: an index can go stale
+     * legitimately if the sync thread removes an item between selection and resolution, and that
+     * is not an invariant violation. Callers on the EDT must null-check.</p>
+     *
+     * @param index item index
+     * @return the {@link DrawItem}, or null
+     */
+    public DrawItem lookupId(int index) {
+        Snapshot snap = snapshot;
+        if (index < 0 || index >= snap.size()) {
+            logger.trace("Lookup: Index out of range: {}", index);
+            return null;
+        }
+        return snap.at(index);
+    }
+
+    /**
+     * Resolve an index against a snapshot order the caller already holds.
+     *
+     * <p>Use inside a single pass, where {@code theseItems} came from one {@link #getItems()} or
+     * {@link Snapshot#order()} call, so the index and the list agree.</p>
+     *
+     * @param theseItems z-ordered ids
+     * @param index      item index
+     * @return the {@link DrawItem}, or null
+     */
+    public DrawItem lookupId(List<ItemId> theseItems, int index) {
+        if (index < 0 || index >= theseItems.size()) {
+            logger.trace("Lookup: Index out of range: {}", index);
+            return null;
+        }
+        return lookupId(theseItems.get(index));
+    }
+
+    /**
+     * Resolve an id against the current snapshot.
+     *
+     * @param id item id
+     * @return the {@link DrawItem}, or null
+     */
+    public DrawItem lookupId(ItemId id) {
+        if (id == null) {
+            return null;
+        }
+        return snapshot.byId().get(id);
+    }
+
+    /**
+     * Resolve a collection of ids to items, skipping any no longer present.
+     *
+     * <p>Single snapshot, so the result is internally consistent. Use for grouping and
+     * multi-selection.</p>
+     *
+     * @param ids item ids
+     * @return the items still present, in the order given
+     */
+    public List<DrawItem> lookupAll(Collection<ItemId> ids) {
+        Snapshot snap = snapshot;
+        List<DrawItem> out = new ArrayList<>(ids.size());
+        for (ItemId id : ids) {
+            DrawItem item = snap.byId().get(id);
+            if (item != null) {
+                out.add(item);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Position of an id in the current z-order.
+     *
+     * <p>Resolve ids to indices at the sync boundary only — an index is valid solely for the
+     * snapshot it came from.</p>
+     *
+     * @param id item id
+     * @return the index, or -1 if not present
+     */
+    public int indexOf(ItemId id) {
+        return snapshot.indexOf(id);
+    }
+
+    /**
+     * Resolve ids to indices against a single snapshot, skipping any no longer present.
+     *
+     * @param ids item ids
+     * @return the indices, ascending
+     */
+    public List<Integer> indicesOf(Collection<ItemId> ids) {
+        Snapshot snap = snapshot;
+        List<Integer> out = new ArrayList<>(ids.size());
+        for (ItemId id : ids) {
+            int index = snap.indexOf(id);
+            if (index != -1) {
+                out.add(index);
+            }
+        }
+        out.sort(null);
+        return out;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutators
+    // -----------------------------------------------------------------------
+
+    /**
+     * Mint the next id. Caller must hold {@code lock}.
+     *
+     * @return a fresh id
+     */
+    private ItemId mint() {
+        return ItemId.freshId();
+    }
+
+    /**
+     * Append item to the end of the z-order.
+     *
+     * @param item the {@link DrawItem}
+     * @return the index at which the item was placed
+     */
+    public int append(DrawItem item) {
+        lock.lock();
+        try {
+            ItemId id = mint();
+            itemsById.put(id, item);
+            items.add(id);
+            int index = items.size() - 1;
+            logger.debug("Create: Appended item at Index: {}", index);
+            publish();
+            return index;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Add item at index.
+     *
+     * <p>The map entry is written before the list entry so that a concurrent reader never
+     * observes an id with no backing item.</p>
+     *
+     * @param index item index
+     * @param item  the {@link DrawItem}
+     * @return the id minted for the new slot
+     */
+    public ItemId addItem(int index, DrawItem item) {
+        lock.lock();
+        try {
+            ItemId id = mint();
+            itemsById.put(id, item);
+            if (index >= 0 && index < items.size()) {
+                items.add(index, id);
+                logger.debug("Create: Added item at Index: {}", index);
+            } else {
+                items.add(id);
+                logger.info("Create: Added item.");
+            }
+            publish();
+            return id;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Replace the item at index, preserving the slot's identity.
+     *
+     * <p>The existing {@link ItemId} is kept and rebound to the new instance. This is what allows
+     * a selection or group membership held as an id to survive the sync layer dropping in a
+     * deserialized replacement.</p>
+     *
+     * <p>Republishes even when the instance is unchanged, so that in-place EDT edits become
+     * visible to snapshot readers and bump the revision. Every EDT mutation must come through
+     * here — one that does not will be invisible to {@link #saveState()}'s revision check.</p>
+     *
+     * @param index item index
+     * @param item  the {@link DrawItem}
+     * @return the slot's id, or null if the index was out of range and the item was appended
+     */
+    public ItemId replaceItem(int index, DrawItem item) {
+        lock.lock();
+        try {
+            ItemId id;
+            if (index >= 0 && index < items.size()) {
+                id = items.get(index);          // keep the slot's identity
+                itemsById.put(id, item);        // rebind to the new instance
+                logger.debug("Update: Replaced item at Index: {}", index);
+            } else {
+                id = mint();
+                itemsById.put(id, item);
+                items.add(id);
+                logger.info("Update: Replaced item.");
+            }
+            publish();
+            return id;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Replace the item bound to an id.
+     *
+     * @param id   the slot id
+     * @param item the {@link DrawItem}
+     * @return true if the id was present and the item was rebound
+     */
+    public boolean replaceItem(ItemId id, DrawItem item) {
+        lock.lock();
+        try {
+            if (!itemsById.containsKey(id)) {
+                logger.trace("Update: Unknown id: {}", id);
+                return false;
+            }
+            itemsById.put(id, item);
+            publish();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Tombstone the item at index. The item remains visible until {@link #removeItems()} commits
+     * the deletion; this is the soft-delete path used by undo.
+     *
+     * @param index item index
+     * @return the {@link DrawItem}, or null if index is out of bounds
+     */
+    public DrawItem deleteItem(int index) {
+        lock.lock();
+        try {
+            if (index < 0 || index >= items.size()) {
+                logger.warn("Delete: Index out of bounds: {}", index);
+                return null;
+            }
+            ItemId id = items.get(index);
+            removed.add(id);
+            logger.debug("Delete: Removed item at Index: {}", index);
+            return itemsById.get(id);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Commit all tombstoned deletions.
+     *
+     * <p>{@code removeAll} performs a single pass rather than one removal per element.</p>
+     */
+    public void removeItems() {
+        lock.lock();
+        try {
+            if (removed.isEmpty()) {
+                return;
+            }
+            List<ItemId> batch = List.copyOf(removed);
+            items.removeAll(batch);
+            batch.forEach(itemsById::remove);
+            removed.clear();
+            publish();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Remove the item at index immediately, bypassing the tombstone.
+     *
+     * @param index item index
+     * @return the removed {@link DrawItem}, or null if out of bounds
+     */
+    public DrawItem removeAt(int index) {
+        lock.lock();
+        try {
+            if (index < 0 || index >= items.size()) {
+                logger.warn("Delete: Index out of bounds: {}", index);
+                return null;
+            }
+            ItemId id = items.remove(index);
+            DrawItem gone = itemsById.remove(id);
+            removed.remove(id);
+            logger.debug("Delete: Removed item at Index: {}", index);
+            publish();
+            return gone;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Remove the item bound to an id immediately.
+     *
+     * @param id the slot id
+     * @return the removed {@link DrawItem}, or null if the id was not present
+     */
+    public DrawItem removeById(ItemId id) {
+        lock.lock();
+        try {
+            if (!items.remove(id)) {
+                logger.trace("Delete: Unknown id: {}", id);
+                return null;
+            }
+            DrawItem gone = itemsById.remove(id);
+            removed.remove(id);
+            publish();
+            return gone;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Move the item at {@code from} to position {@code to} in the z-order.
+     *
+     * <p>A single atomic reposition, not a remove followed by an add: the slot keeps its
+     * {@link ItemId}, so a selection or group membership held as an id survives the move. Doing
+     * this as add-then-remove would mint a new id and silently drop the item out of any group
+     * holding the old one.</p>
+     *
+     * <p>{@code to} is the index the item ends up at in the resulting list, and is clamped to
+     * range. Only one snapshot is published, so readers never observe the item duplicated or
+     * missing.</p>
+     *
+     * @param from current index
+     * @param to   destination index
+     * @return true if the item moved
+     */
+    public boolean move(int from, int to) {
+        lock.lock();
+        try {
+            if (from < 0 || from >= items.size()) {
+                logger.warn("Move: Index out of bounds: {}", from);
+                return false;
+            }
+            int target = Math.max(0, Math.min(to, items.size() - 1));
+            if (target == from) {
+                return false;
+            }
+            ItemId id = items.remove(from);
+            items.add(target, id);
+            logger.debug("Move: {} to {1}", new Object[] {from, target});
+            publish();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Move the item bound to an id to position {@code to} in the z-order.
+     *
+     * @param id the slot id
+     * @param to destination index
+     * @return true if the item moved
+     */
+    public boolean moveById(ItemId id, int to) {
+        lock.lock();
+        try {
+            int from = items.indexOf(id);
+            if (from == -1) {
+                logger.trace("Move: Unknown id: {}", id);
+                return false;
+            }
+            int target = Math.max(0, Math.min(to, items.size() - 1));
+            if (target == from) {
+                return false;
+            }
+            items.remove(from);
+            items.add(target, id);
+            publish();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Insert items at an index, in order, as one publication.
+     *
+     * @param index  insertion point; out-of-range appends
+     * @param toAdd  the items
+     * @return the ids minted, in the order given
+     */
+    public List<ItemId> insertAll(int index, List<DrawItem> toAdd) {
+        lock.lock();
+        try {
+            List<ItemId> ids = new ArrayList<>(toAdd.size());
+            batchDepth++;
+            try {
+                int at = (index >= 0 && index <= items.size()) ? index : items.size();
+                for (DrawItem item : toAdd) {
+                    ItemId id = mint();
+                    itemsById.put(id, item);
+                    items.add(at++, id);
+                    ids.add(id);
+                }
+            } finally {
+                batchDepth--;
+            }
+            publish();
+            return ids;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Remove several items by id as one publication.
+     *
+     * @param ids the slot ids
+     * @return the number removed
+     */
+    public int removeAllById(Collection<ItemId> ids) {
+        lock.lock();
+        try {
+            int count = 0;
+            batchDepth++;
+            try {
+                for (ItemId id : ids) {
+                    if (items.remove(id)) {
+                        itemsById.remove(id);
+                        removed.remove(id);
+                        count++;
+                    }
+                }
+            } finally {
+                batchDepth--;
+            }
+            logger.debug("Delete: Removed {} items.", count);
+            publish();
+            return count;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Discard all items. Ids are not reused.
+     */
+    public void clear() {
+        lock.lock();
+        try {
+            items.clear();
+            itemsById.clear();
+            removed.clear();
+            publish();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Apply several mutations as one unit, publishing a single snapshot at the end.
+     *
+     * <p>Use this for inbound sync deltas and for streaming loads: it amortises the O(n) snapshot
+     * rebuild across the whole batch and prevents readers from observing a half-applied delta.
+     * Nesting is supported; only the outermost call publishes.</p>
+     *
+     * <p>The lock is held for the duration, so the work must not block or call back onto the
+     * EDT.</p>
+     *
+     * @param work the mutations to apply
+     */
+    public void batch(Runnable work) {
+        lock.lock();
+        try {
+            batchDepth++;
+            try {
+                work.run();
+            } finally {
+                batchDepth--;
+            }
+            publish();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Rebuild and publish the snapshot. Caller must hold {@code lock}.
+     */
+    private void publish() {
+        if (batchDepth > 0) {
+            return;
+        }
+        revision++;
+        snapshot = new Snapshot(List.copyOf(items), Map.copyOf(itemsById), revision);
+        Runnable callback = repaintCallback;
+        if (callback != null) {
+            SwingUtilities.invokeLater(callback);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Persistence
+    // -----------------------------------------------------------------------
+
+    /** @return the current publication revision */
+    public long revision() {
+        return snapshot.revision();
+    }
+
+    /**
+     * Capture the document for saving on the EDT.
+     *
+     * <p>Safe when the serialization itself also runs on the EDT. For a background writer use
+     * {@link #saveState()} instead — this method's list is stable but its <em>items</em> are live
+     * references the EDT may still mutate.</p>
+     *
+     * @return the items in z-order
+     */
+    public List<DrawItem> save() {
+        return getDrawItems();
+    }
+
+    /**
+     * Capture the document together with the revision it was taken at, for a background writer.
+     *
+     * <p>The capture fixes the set and ordering of items, but not the items themselves: the EDT
+     * may mutate one in place while the writer is reading its fields, producing an item that
+     * serializes half-old and half-new. Compare {@link #revision()} after the write to detect
+     * this:</p>
+     *
+     * <pre>{@code
+     * SaveState state = store.saveState();
+     * byte[] bytes = serialize(state.items());
+     * if (store.revision() != state.revision()) {
+     *     // document changed mid-write; bytes may contain a torn item — re-capture
+     * } else {
+     *     writeToDisk(bytes);
+     * }
+     * }</pre>
+     *
+     * <p>This detects rather than prevents, so bound the retries — a few attempts, then fall back
+     * to capturing on the EDT via {@code invokeAndWait} and writing those bytes off-thread. The
+     * check is only sound if every EDT mutation republishes, which means going through
+     * {@link #replaceItem}; a mutation that does not republish will not move the revision and
+     * will not be detected.</p>
+     *
+     * @return the capture
+     */
+    public SaveState saveState() {
+        Snapshot snap = snapshot;
+        List<DrawItem> out = new ArrayList<>(snap.size());
+        for (ItemId id : snap.order()) {
+            DrawItem item = snap.byId().get(id);
+            if (item != null) {
+                out.add(item);
+            }
+        }
+        return new SaveState(out, snap.revision());
+    }
+
+    /**
+     * Replace the entire document.
+     *
+     * <p>Clear and load happen under one lock hold and publish a single snapshot, so readers never
+     * see an empty or half-populated canvas, and the O(n) rebuild happens once rather than once
+     * per item. Loading n items through repeated {@link #append(DrawItem)} instead is O(n²) and
+     * queues n repaints.</p>
+     *
+     * <p>Fresh ids are minted for the loaded items, since the serialized format carries none. Any
+     * ids held from before the load — in selection state, group membership or undo entries — are
+     * therefore stale and must be discarded by the caller.</p>
+     *
+     * @param loaded the items in z-order
+     */
+    public void load(List<DrawItem> loaded) {
+        lock.lock();
+        try {
+            batchDepth++;
+            try {
+                items.clear();
+                itemsById.clear();
+                removed.clear();
+                for (DrawItem item : loaded) {
+                    ItemId id = mint();
+                    itemsById.put(id, item);
+                    items.add(id);
+                }
+            } finally {
+                batchDepth--;
+            }
+            logger.debug("Load: Loaded {} items.", items.size());
+            publish();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -832,7 +832,7 @@ public class ItemStore {
         return snapshot.revision();
     }
 
-        /**
+    /**
      * Capture the document together with the revision it was taken at, for a background writer.
      *
      * <p>The capture fixes the set and ordering of items, but not the items themselves: the EDT
@@ -907,4 +907,5 @@ public class ItemStore {
             lock.unlock();
         }
     }
+
 }

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -515,6 +515,38 @@ public class ItemStore {
     }
 
     /**
+     * Republish a slot whose item was edited in place.
+     *
+     * <p>The instance is unchanged; this exists so that an EDT edit made directly on a published
+     * item still reaches readers. It marks the slot dirty exactly as {@link #replaceItem} does,
+     * which is what a reader needs — an unchanged instance is indistinguishable from no change at
+     * all by {@code ==} or {@code equals}, so without the dirty mark the edit is filtered out and
+     * the node keeps its old geometry. It also bumps the revision, without which the change is
+     * invisible to {@link #saveState()}'s check and the document can be thought unmodified when it
+     * is not.</p>
+     *
+     * <p>In-place editing is legal only from the EDT — see the mutability contract on this class.
+     * The sync thread must go through {@link #replaceItem} with a fresh instance.</p>
+     *
+     * @param id the slot id
+     * @return true if the id was present
+     */
+    public boolean touch(ItemId id) {
+        lock.lock();
+        try {
+            if (!itemsById.containsKey(id)) {
+                logger.trace("Touch: Unknown id: {}", id);
+                return false;
+            }
+            dirty.add(id);
+            publish();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
      * Tombstone the item at index. The item remains visible until {@link #removeItems()} commits
      * the deletion; this is the soft-delete path used by undo.
      *

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -808,7 +808,7 @@ public class ItemStore {
      * Rebuild and publish the snapshot. Caller must hold {@code lock}.
      *
      * <p>The listener is notified with the lock still held and on the writing thread, so it must
-     * not block or touch the scene graph — it schedules and returns. See
+     * not block or touch the UI — it schedules and returns. See
      * {@link FxSnapshotBinder#attach}.</p>
      */
     private void publish() {

--- a/src/main/java/net/perspective/draw/ItemStore.java
+++ b/src/main/java/net/perspective/draw/ItemStore.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.swing.SwingUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.perspective.draw.geom.DrawItem;
@@ -168,14 +167,23 @@ public class ItemStore {
     /** Tombstones awaiting commit by {@link #removeItems()}. Guarded by {@code lock}. */
     private final Set<ItemId> removed = new LinkedHashSet<>();
 
+    /**
+     * Slots written since the last {@link #drainDirty()}. Guarded by {@code lock}.
+     *
+     * <p>Exists because an in-place edit is undetectable by a reader. The EDT is permitted to
+     * mutate a published item and republish the same instance, which no comparison — {@code ==}
+     * or {@code equals} — can distinguish from no change at all. So the writer records it.</p>
+     *
+     * <p>Accumulates rather than being cleared per publication: a reader that coalesces several
+     * publications into one pass must still learn about every slot touched across them.</p>
+     */
+    private final Set<ItemId> dirty = new LinkedHashSet<>();
+
     private long revision;
     private int batchDepth;
 
     /** The published view. Volatile: written under lock, read without. */
     private volatile Snapshot snapshot = new Snapshot(List.of(), Map.of(), 0L);
-
-    /** Invoked after each publication, on the EDT. May be null. */
-    private Runnable repaintCallback;
 
     /**
      * Notified after each publication.
@@ -201,22 +209,13 @@ public class ItemStore {
     /**
      * Set the listener notified after each publication.
      *
-     * <p>Swing: {@code store.setListener(r -> SwingUtilities.invokeLater(canvas::repaint))}.
-     * JavaFX: see {@code FxSnapshotBinder}.</p>
+     * <p>This is the only notification the store emits — see {@link FxSnapshotBinder}, which
+     * registers here and marshals onto the FX thread. Nothing renders if it is left unset.</p>
      *
      * @param listener the listener, or null to disable
      */
     public void setListener(SnapshotListener listener) {
         this.listener = listener;
-    }
-
-    /**
-     * Set the callback invoked on the EDT after each publication.
-     *
-     * @param repaintCallback typically {@code canvas::repaint}, or null to disable
-     */
-    public void setRepaintCallback(Runnable repaintCallback) {
-        this.repaintCallback = repaintCallback;
     }
 
     /**
@@ -226,6 +225,37 @@ public class ItemStore {
      */
     public Snapshot snapshot() {
         return snapshot;
+    }
+
+    /**
+     * Take the set of slots written since the last call, and clear it.
+     *
+     * <p>Identifies items that changed without changing instance — an EDT edit applied in place
+     * and republished. A reader cannot detect those itself, so the store records them here.</p>
+     *
+     * <p><strong>Drain before reading {@link #snapshot()}, never after.</strong> Draining first
+     * means every id returned is guaranteed to be at least as new in that snapshot; a write
+     * landing in the gap is simply not drained, and the publication it performed has already
+     * scheduled the reader again, so it is picked up on the next pass. Draining second can strand
+     * a write: its id is taken while its state is missing from the older snapshot already read,
+     * and nothing schedules another pass.</p>
+     *
+     * <p>Single-consumer: whoever drains takes sole responsibility for applying the result.</p>
+     *
+     * @return the dirty slot ids, in write order
+     */
+    public Set<ItemId> drainDirty() {
+        lock.lock();
+        try {
+            if (dirty.isEmpty()) {
+                return Set.of();
+            }
+            Set<ItemId> out = new LinkedHashSet<>(dirty);
+            dirty.clear();
+            return out;
+        } finally {
+            lock.unlock();
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -471,6 +501,7 @@ public class ItemStore {
                 items.add(id);
                 logger.info("Update: Replaced item.");
             }
+            dirty.add(id);
             publish();
             return id;
         } finally {
@@ -493,6 +524,7 @@ public class ItemStore {
                 return false;
             }
             itemsById.put(id, item);
+            dirty.add(id);
             publish();
             return true;
         } finally {
@@ -724,6 +756,7 @@ public class ItemStore {
             items.clear();
             itemsById.clear();
             removed.clear();
+            dirty.clear();                  // the slots are gone; nothing to refresh
             publish();
         } finally {
             lock.unlock();
@@ -759,6 +792,10 @@ public class ItemStore {
 
     /**
      * Rebuild and publish the snapshot. Caller must hold {@code lock}.
+     *
+     * <p>The listener is notified with the lock still held and on the writing thread, so it must
+     * not block or touch the scene graph — it schedules and returns. See
+     * {@link FxSnapshotBinder#attach}.</p>
      */
     private void publish() {
         if (batchDepth > 0) {
@@ -766,9 +803,9 @@ public class ItemStore {
         }
         revision++;
         snapshot = new Snapshot(List.copyOf(items), Map.copyOf(itemsById), revision);
-        Runnable callback = repaintCallback;
-        if (callback != null) {
-            SwingUtilities.invokeLater(callback);
+        SnapshotListener notify = listener;
+        if (notify != null) {
+            notify.published(revision);
         }
     }
 
@@ -854,6 +891,7 @@ public class ItemStore {
                 items.clear();
                 itemsById.clear();
                 removed.clear();
+                dirty.clear();              // ids are re-minted below
                 for (DrawItem item : loaded) {
                     ItemId id = mint();
                     itemsById.put(id, item);

--- a/src/main/java/net/perspective/draw/MapController.java
+++ b/src/main/java/net/perspective/draw/MapController.java
@@ -65,6 +65,7 @@ public class MapController {
 
     private final Provider<DrawingArea> drawareaProvider;
     private final Provider<CanvasView> viewProvider;
+    @Inject ItemStore store;
     @Inject Provider<StreetMap> streetMapProvider;
     private Slider zoomSlider;
     private Button zoomInButton;
@@ -72,7 +73,8 @@ public class MapController {
     private Button quiticon;
     private TextField geoLocation;
     private StreetMap map;
-    private int mapindex;
+    /** The slot being mapped. An id, not an index: mapping mode outlives document edits. */
+    private ItemId mapid;
 
     private final String SVG_QUIT_A = "M3.7732425 22.718011L22.702213 3.7890409";
     private final String SVG_QUIT_B = "M3.7732425 3.7890409L22.702213 22.718011";
@@ -88,7 +90,7 @@ public class MapController {
     public MapController(Provider<DrawingArea> drawareaProvider, Provider<CanvasView> viewProvider) {
         this.drawareaProvider = drawareaProvider;
         this.viewProvider = viewProvider;
-        mapindex = -1;
+        mapid = null;
     }
 
     /**
@@ -106,9 +108,14 @@ public class MapController {
         ImageItem img = new ImageItem(image);
         int index = viewProvider.get().setImageItem(img);
         streetmap.setImage(index, width, height);
-        viewProvider.get().setNewItem(streetmap);
+        /*
+         * Append directly rather than through setNewItem, which replaces the top item when a
+         * drawing is in progress. The append reports the slot it landed in, so the selection no
+         * longer needs an indexOf scan to find the item just added.
+         */
+        ItemId id = viewProvider.get().appendItemToCanvas(streetmap);
         viewProvider.get().resetNewItem();
-        viewProvider.get().setSelected(viewProvider.get().getDrawings().indexOf(streetmap));
+        viewProvider.get().setSelected(id);
         this.initMap();
     }
     
@@ -117,27 +124,27 @@ public class MapController {
      */
     public void initMap() {
         viewProvider.get().setMapping(true);
-        mapindex = viewProvider.get().getSelected();
+        mapid = viewProvider.get().getSelectedId();
         // Remove MapView event filters
-        if (viewProvider.get().getDrawings().get(mapindex) instanceof StreetMap streetMap) {
+        if (store.lookupId(mapid) instanceof StreetMap streetMap) {
             map = streetMap;
             map.resetHandlers();
             initializeZoomSlider(map);
         }
     }
-    
+
     /**
      * MapView event handlers need to be consumed when mapping control is not active.
      */
     public void finaliseMap() {
-        if (mapindex != -1) {
-            DrawItem item = viewProvider.get().getDrawings().get(mapindex);
-            if (item instanceof StreetMap streetMap) {
+        if (mapid != null) {
+            // Null if the map went away while mapping mode was open; still tear the mode down.
+            if (store.lookupId(mapid) instanceof StreetMap streetMap) {
                 streetMap.filterHandlers();
                 resizeMap(streetMap);
             }
             viewProvider.get().setMapping(false);
-            mapindex = -1;
+            mapid = null;
             removeSlider();
         }
     }

--- a/src/main/java/net/perspective/draw/ShareUtils.java
+++ b/src/main/java/net/perspective/draw/ShareUtils.java
@@ -305,6 +305,7 @@ public class ShareUtils {
         PDFWorker pdfWorker = pdfWorkerProvider.get();
         pdfWorker.setFile(file);
         pdfWorker.setMargin(this.margin);
+        pdfWorker.captureDocument();             // FX thread: see captureDocument()
         controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
         controller.setProgressIndeterminate();
         executor.submit(pdfWorker);
@@ -337,6 +338,7 @@ public class ShareUtils {
         SVGWorker svgWorker = svgWorkerProvider.get();
         svgWorker.setFile(file);
         svgWorker.setMargin(this.margin);
+        svgWorker.captureDocument();             // FX thread: see captureDocument()
         controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
         controller.setProgressIndeterminate();
         executor.submit(svgWorker);
@@ -370,6 +372,7 @@ public class ShareUtils {
         pngWorker.setFile(file);
         pngWorker.setOpacity(false);
         pngWorker.setMargin(this.margin);
+        pngWorker.captureDocument();             // FX thread: see captureDocument()
         controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
         controller.setProgressIndeterminate();
         executor.submit(pngWorker);
@@ -401,6 +404,7 @@ public class ShareUtils {
         PNGWorker pngWorker = pngWorkerProvider.get();
         pngWorker.setFile(file);
         pngWorker.setMargin(this.margin);
+        pngWorker.captureDocument();             // FX thread: see captureDocument()
         controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
         controller.setProgressIndeterminate();
         executor.submit(pngWorker);

--- a/src/main/java/net/perspective/draw/ShareUtils.java
+++ b/src/main/java/net/perspective/draw/ShareUtils.java
@@ -205,7 +205,7 @@ public class ShareUtils {
      */
     public void exportCanvas() {
         // Detect empty canvas
-        if (view.getDrawings().isEmpty()) {
+        if (view.isEmpty()) {
             return;
         }
 
@@ -271,6 +271,7 @@ public class ShareUtils {
     public void writeCanvas(File file) {
         WriteOutStreamer streamer = writeOutStreamerProvider.get();
         streamer.setFile(file);
+        streamer.captureDocument();                  // FX thread: see captureDocument()
         this.canvasfile = file;
         controller.getProgressVisibleProperty().setValue(Boolean.TRUE);
         controller.getProgressProperty().bind(streamer.progressProperty());
@@ -282,7 +283,7 @@ public class ShareUtils {
      */
     public void exportPDF() {
         // Detect empty canvas
-        if (view.getDrawings().isEmpty()) {
+        if (view.isEmpty()) {
             return;
         }
 
@@ -314,7 +315,7 @@ public class ShareUtils {
      */
     public void exportSVG() {
         // Detect empty canvas
-        if (view.getDrawings().isEmpty()) {
+        if (view.isEmpty()) {
             return;
         }
 
@@ -346,7 +347,7 @@ public class ShareUtils {
      */
     public void exportPNG() {
         // Detect empty canvas
-        if (view.getDrawings().isEmpty()) {
+        if (view.isEmpty()) {
             return;
         }
 
@@ -379,7 +380,7 @@ public class ShareUtils {
      */
     public void snapshotPNG() {
         // Detect empty canvas
-        if (view.getDrawings().isEmpty()) {
+        if (view.isEmpty()) {
             controller.getSnapshotProperty().setValue(false);
             return;
         }

--- a/src/main/java/net/perspective/draw/TextController.java
+++ b/src/main/java/net/perspective/draw/TextController.java
@@ -149,8 +149,8 @@ public class TextController {
      * Cut the selected text
      */
     public void cutSelectedText() {
-        if (viewProvider.get().isEditing()) {
-            Text item = (Text) viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
+        if (viewProvider.get().isEditing()
+            && viewProvider.get().getSelectedDrawItem() instanceof Text item) {
             editor.editText(item);
             editor.cutText();
             editor.commitText(item);
@@ -163,8 +163,8 @@ public class TextController {
      * Copy the selected text
      */
     public void copySelectedText() {
-        if (viewProvider.get().isEditing()) {
-            Text item = (Text) viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
+        if (viewProvider.get().isEditing()
+            && viewProvider.get().getSelectedDrawItem() instanceof Text item) {
             editor.editText(item);
             editor.copyText();
             editor.commitText(item);
@@ -175,8 +175,8 @@ public class TextController {
      * Paste the selected text
      */
     public void pasteSelectedText() {
-        if (viewProvider.get().isEditing()) {
-            Text item = (Text) viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
+        if (viewProvider.get().isEditing()
+            && viewProvider.get().getSelectedDrawItem() instanceof Text item) {
             editor.editText(item);
             editor.pasteText();
             editor.commitText(item);
@@ -213,8 +213,8 @@ public class TextController {
      * @param format text format property
      */
     private void formatSelectedRichText(int format) {
-        if (viewProvider.get().isEditing()) {
-            Text item = (Text) viewProvider.get().getDrawings().get(viewProvider.get().getSelected());
+        if (viewProvider.get().isEditing()
+            && viewProvider.get().getSelectedDrawItem() instanceof Text item) {
             editor.editText(item);
             styler.clearStoredMarks();
             Set<String> styles = styler.detectStyles();

--- a/src/main/java/net/perspective/draw/TextController.java
+++ b/src/main/java/net/perspective/draw/TextController.java
@@ -156,7 +156,7 @@ public class TextController {
             editor.commitText(item);
             item.setDimensions();
         }
-        viewProvider.get().moveSelection(viewProvider.get().getSelected());
+        viewProvider.get().refreshSelection();
     }
 
     /**
@@ -182,7 +182,7 @@ public class TextController {
             editor.commitText(item);
             item.setDimensions();
         }
-        viewProvider.get().moveSelection(viewProvider.get().getSelected());
+        viewProvider.get().refreshSelection();
     }
 
     /**
@@ -202,7 +202,7 @@ public class TextController {
         if (isRichText()) {
             this.formatSelectedRichText(format);
         }
-        viewProvider.get().moveSelection(viewProvider.get().getSelected());
+        viewProvider.get().refreshSelection();
     }
 
     /**

--- a/src/main/java/net/perspective/draw/TextController.java
+++ b/src/main/java/net/perspective/draw/TextController.java
@@ -127,6 +127,11 @@ public class TextController {
         editor.setCaretStart(start);
         editor.setCaretEnd(start);
         item.setDimensions();
+        /*
+         * Edited in place. Safe to commit against the selection because the only caller,
+         * TextItemBehaviour.editItem, registers the id before calling in.
+         */
+        viewProvider.get().commitSelection();
     }
 
     /**
@@ -155,6 +160,7 @@ public class TextController {
             editor.cutText();
             editor.commitText(item);
             item.setDimensions();
+            viewProvider.get().commitSelection();     // edited in place; republish to refresh
         }
         viewProvider.get().refreshSelection();
     }
@@ -181,6 +187,7 @@ public class TextController {
             editor.pasteText();
             editor.commitText(item);
             item.setDimensions();
+            viewProvider.get().commitSelection();     // edited in place; republish to refresh
         }
         viewProvider.get().refreshSelection();
     }
@@ -245,6 +252,7 @@ public class TextController {
             }
             editor.commitText(item);
             item.setDimensions();
+            viewProvider.get().commitSelection();     // edited in place; republish to refresh
         }
     }
 

--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -119,7 +119,7 @@ public class SelectionHandler implements Handler {
             drawarea.getScene().setCursor(Cursor.DEFAULT);
             drawarea.setRotationMode(false);
         }
-        if (view.getSelected() != -1 && !listener.getRightClick()) {
+        if (view.hasSelection() && !listener.getRightClick()) {
             view.updateSelectedItem();
             view.refreshSelection();
             context.resetContainment();
@@ -310,7 +310,7 @@ public class SelectionHandler implements Handler {
 
     @Override
     public void dragEvent() {
-        if (view.getSelected() != -1) {
+        if (view.hasSelection()) {
             double xinc = listener.getTempX() - listener.getStartX();
             double yinc = listener.getTempY() - listener.getStartY();
 

--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -120,7 +120,14 @@ public class SelectionHandler implements Handler {
             drawarea.setRotationMode(false);
         }
         if (view.hasSelection() && !listener.getRightClick()) {
-            view.updateSelectedItem();
+            if (view.isSingleSelection()) {
+                view.updateSelectedItem();
+            } else {
+                // A multi-selection is restyled only from the toolbar, so read properties for
+                // the dropper but write none: the gesture must not conform every member to the
+                // current settings.
+                view.pickSelectedItem();
+            }
             view.refreshSelection();
             context.resetContainment();
         }
@@ -383,7 +390,9 @@ public class SelectionHandler implements Handler {
                 if (activeStrategy.isPresent()) {
                     context.setBehaviour(activeStrategy.get());
                     context.alter(item, listener.getTempX(), listener.getTempY());
-                    item.updateProperties(drawarea);
+                    if (view.isSingleSelection()) {
+                        item.updateProperties(drawarea);
+                    }
                     view.updateCanvasItem(selection, item);
                     view.moveSelection(selection);
                 } else {
@@ -424,7 +433,9 @@ public class SelectionHandler implements Handler {
                             item.moveTo(xinc, yinc);
                         }
                     }
-                    item.updateProperties(drawarea);
+                    if (view.isSingleSelection()) {
+                        item.updateProperties(drawarea);
+                    }
                     view.updateCanvasItem(selection, item);
                     view.moveSelection(selection);
                 }

--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -232,6 +232,19 @@ public class SelectionHandler implements Handler {
     @Override
     public void clickEvent() {
         DrawItem current = store.lookupId(view.getSelectedId());
+        if (view.isEditing() && current == null) {
+            /*
+             * The item being edited went away under us — a sync removal, most likely. Leave edit
+             * mode rather than sit in it with nothing selected, where keystrokes reach no item and
+             * the caret animates against a stale id.
+             */
+            Editor editor = textController.getEditor();
+            view.setSelected(-1);
+            view.setEditing(KeyHandlerType.MOVE);
+            editor.setCaretStart(0);
+            editor.setCaretEnd(0);
+            return;
+        }
         if (view.isEditing() && current != null && !listener.wasDragged()) {
             if (!current.contains(listener.getTempX(), listener.getTempY())) {
                 Editor editor = textController.getEditor();

--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -34,6 +34,9 @@ import javax.inject.Provider;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
+import net.perspective.draw.ItemStore;
+import net.perspective.draw.ItemStore.Snapshot;
 import net.perspective.draw.TextController;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.enums.DrawingType;
@@ -67,6 +70,7 @@ public class SelectionHandler implements Handler {
     private final DrawingArea drawarea;
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject DrawAreaListener listener;
     @Inject BehaviourContext context;
     @Inject FigureFactory figurefactory;
@@ -127,29 +131,34 @@ public class SelectionHandler implements Handler {
 
     @Override
     public void downEvent() {
-        List<DrawItem> drawings = view.getDrawings();
+        Snapshot snap = store.snapshot();             // one snapshot for the whole gesture
         if (view.isEditing()) {
             // Text isEditing code here
             if (!listener.getRightClick()) {
-                DrawItem item = drawings.get(view.getSelected());
+                ItemId id = view.getSelectedId();
+                DrawItem item = snap.get(id);
                 if (item instanceof Text) {
                     context.setBehaviour(textItemBehaviourProvider.get());
-                    context.select(item, view.getSelected());
+                    context.select(item, id);
                 }
             }
         } else {
-            if (!drawings.isEmpty() && !listener.getRightClick()) {
-                int i = drawings.size() - 1;
+            if (!snap.isEmpty() && !listener.getRightClick()) {
+                ItemId selectedId = view.getSelectedId();
                 context.setContainment(ContainsType.NONE);
-                do {
-                    DrawItem item = drawings.get(i);
+                for (int i = snap.size() - 1; i >= 0; i--) {   // topmost first
+                    ItemId id = snap.order().get(i);
+                    DrawItem item = snap.get(id);
+                    if (item == null) {
+                        continue;
+                    }
                     boolean found;
                     // The rotate handle is only drawn on the selected item, so
                     // only that item offers it as a hit target.
-                    if (i == view.getSelected()) {
+                    if (id.equals(selectedId)) {
                         activeStrategy = Optional.ofNullable(rotateBehaviourProvider.get());
                         context.setBehaviour(activeStrategy.get());
-                        found = context.select(item, i);
+                        found = context.select(item, id);
                         if (found) {
                             drawarea.setRotationMode(true);
                             break;
@@ -158,66 +167,63 @@ public class SelectionHandler implements Handler {
                     activeStrategy = Optional.empty();
                     if (item instanceof Figure) {
                         context.setBehaviour(figureItemBehaviourProvider.get());
-                        found = context.select(item, i);
+                        found = context.select(item, id);
                         if (found) {
                             break;
                         }
                     } else if (item instanceof Picture) {
                         if (item instanceof StreetMap) {
                             context.setBehaviour(mapItemBehaviourProvider.get());
-                            found = context.select(item, i);
+                            found = context.select(item, id);
                             if (found) {
                                 break;
                             }
                         } else {
                             context.setBehaviour(pictureItemBehaviourProvider.get());
-                            found = context.select(item, i);
+                            found = context.select(item, id);
                             if (found) {
                                 break;
                             }
                         }
                     } else if (item instanceof Grouped) {
                         context.setBehaviour(groupedItemBehaviourProvider.get());
-                        found = context.select(item, i);
+                        found = context.select(item, id);
                         if (found) {
                             break;
                         }
-                     } else if (item != null && item.contains(listener.getStartX(), listener.getStartY())) {
+                    } else if (item.contains(listener.getStartX(), listener.getStartY())) {
                         // Rest of Shapes
-                        view.setSelected(i);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.SHAPE);
                         break;
                     }
-                    i--;
-                } while (i >= 0);
+                }
                 if (context.getContainment().equals(ContainsType.NONE) && (!view.isMultiSelected() || !drawarea.isMultiSelectEnabled())) {
                     view.setSelected(-1);
                 }
             }
         }
-        if (view.getSelected() != -1 && listener.isSnapEnabled()) {
-            DrawItem selectedItem = drawings.get(view.getSelected());
-            if (selectedItem != null) {
-                CanvasPoint start = selectedItem.getStart();
-                context.setOmega(start.getX(), start.getY());
-            }
+        ItemId selectedId = view.getSelectedId();     // re-read: the loop above may have changed it
+        DrawItem selectedItem = snap.get(selectedId);
+        if (selectedItem != null && listener.isSnapEnabled()) {
+            CanvasPoint start = selectedItem.getStart();
+            context.setOmega(start.getX(), start.getY());
         }
         /**
          * setup data structures for guides
          */
-        if (view.getSelected() != -1 && !listener.isSnapEnabled() && drawarea.isGuideEnabled() && drawings.size() < 15) {
+        if (selectedItem != null && !listener.isSnapEnabled() && drawarea.isGuideEnabled() && snap.size() < 15) {
             coordsX = new ArrayList<>();
             coordsY = new ArrayList<>();
             midX = new ArrayList<>();
             midY = new ArrayList<>();
-            DrawItem item = drawings.get(view.getSelected());
-            if (item != null) {
-                for (var drawing : drawings) {
-                    if (drawings.indexOf(drawing) != view.getSelected()) {
-                        if (!item.bounds().intersects(drawing.bounds().getBounds2D())) {
-                            computeCoords(drawing);
-                        }
-                    }
+            for (ItemId id : snap.order()) {
+                if (id.equals(selectedId)) {
+                    continue;                         // was an O(n) indexOf scan, and wrong for equal items
+                }
+                DrawItem drawing = snap.get(id);
+                if (drawing != null && !selectedItem.bounds().intersects(drawing.bounds().getBounds2D())) {
+                    computeCoords(drawing);
                 }
             }
         }
@@ -225,8 +231,8 @@ public class SelectionHandler implements Handler {
 
     @Override
     public void clickEvent() {
-        if (view.isEditing() && view.getSelected() != -1 && !listener.wasDragged()) {
-            DrawItem current = view.getDrawings().get(view.getSelected());
+        DrawItem current = store.lookupId(view.getSelectedId());
+        if (view.isEditing() && current != null && !listener.wasDragged()) {
             if (!current.contains(listener.getTempX(), listener.getTempY())) {
                 Editor editor = textController.getEditor();
                 if (current instanceof Text item) {
@@ -241,32 +247,30 @@ public class SelectionHandler implements Handler {
             }
         }
         if (listener.doubleClicked()) {
-            List<DrawItem> drawings = view.getDrawings();
-            if (!drawings.isEmpty()) {
-                int i = drawings.size() - 1;
-                do {
-                    DrawItem item = drawings.get(i);
-                    if (item.contains(listener.getTempX(), listener.getTempY())) {
-                        if (item instanceof Text) {
-                            context.setBehaviour(textItemBehaviourProvider.get());
-                            context.edit(item, i);
-                            break;
-                        } else if (item instanceof StreetMap) {
-                            context.setBehaviour(mapItemBehaviourProvider.get());
-                            context.edit(item, i);
-                            break;
-                        }
-                    }
-                    i--;
-                } while (i >= 0);
+            Snapshot snap = store.snapshot();
+            for (int i = snap.size() - 1; i >= 0; i--) {       // topmost first
+                ItemId id = snap.order().get(i);
+                DrawItem item = snap.get(id);
+                if (item == null || !item.contains(listener.getTempX(), listener.getTempY())) {
+                    continue;
+                }
+                if (item instanceof Text) {
+                    context.setBehaviour(textItemBehaviourProvider.get());
+                    context.edit(item, id);
+                    break;
+                } else if (item instanceof StreetMap) {
+                    context.setBehaviour(mapItemBehaviourProvider.get());
+                    context.edit(item, id);
+                    break;
+                }
             }
         }
     }
 
     @Override
     public void hoverEvent() {
-        if (view.getSelected() != -1) {
-            DrawItem item = view.getDrawings().get(view.getSelected());
+        DrawItem item = store.lookupId(view.getSelectedId());
+        if (item != null) {
             if (item instanceof Figure) {
                 context.setBehaviour(figureItemBehaviourProvider.get());
                 context.hover(item);
@@ -297,16 +301,16 @@ public class SelectionHandler implements Handler {
             double xinc = listener.getTempX() - listener.getStartX();
             double yinc = listener.getTempY() - listener.getStartY();
 
-            for (Integer selection : view.getMultiSelection()) {
-                DrawItem item = view.getDrawings().get(selection);
+            for (ItemId selection : view.getMultiSelection()) {
+                DrawItem item = store.lookupId(selection);
 
                 if (item == null) {
-                    continue; // Skip null items
+                    continue;                         // removed since selection
                 }
 
                 if (listener.isSnapEnabled()) {
                     context.setOmega(context.getOmega().getX() + xinc, context.getOmega().getY() + yinc);
-                } else if (drawarea.isGuideEnabled() && view.getDrawings().size() < 15) {
+                } else if (drawarea.isGuideEnabled() && store.size() < 15) {
                     drawarea.resetGuides();
                     // compute bounds X
                     Double topX = item.getTop()[0].getX();

--- a/src/main/java/net/perspective/draw/event/SelectionHandler.java
+++ b/src/main/java/net/perspective/draw/event/SelectionHandler.java
@@ -121,7 +121,7 @@ public class SelectionHandler implements Handler {
         }
         if (view.getSelected() != -1 && !listener.getRightClick()) {
             view.updateSelectedItem();
-            view.moveSelection(view.getSelected());
+            view.refreshSelection();
             context.resetContainment();
         }
         activeStrategy = Optional.empty();

--- a/src/main/java/net/perspective/draw/event/TextHandler.java
+++ b/src/main/java/net/perspective/draw/event/TextHandler.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
+import net.perspective.draw.ItemStore;
 import net.perspective.draw.TextController;
 import net.perspective.draw.enums.KeyHandlerType;
 import net.perspective.draw.event.behaviours.BehaviourContext;
@@ -45,6 +47,7 @@ public class TextHandler implements Handler {
 
     private final DrawingArea drawarea;
     private final CanvasView view;
+    @Inject ItemStore store;
     @Inject DrawAreaListener listener;
     @Inject BehaviourContext context;
     @Inject TextController textController;
@@ -71,9 +74,9 @@ public class TextHandler implements Handler {
     public void downEvent() {
         if (view.isEditing()) {
             // Text isEditing code here
-            int selected = view.getSelected();
-            if (!listener.getRightClick() && selected != -1) {
-                DrawItem item = view.getDrawings().get(selected);
+            ItemId selected = view.getSelectedId();
+            DrawItem item = store.lookupId(selected);
+            if (!listener.getRightClick() && item != null) {
                 if (item instanceof Text && item.contains(listener.getStartX(), listener.getStartY())) {
                     context.setBehaviour(textItemBehaviourProvider.get());
                     context.select(item, selected);

--- a/src/main/java/net/perspective/draw/event/TextHandler.java
+++ b/src/main/java/net/perspective/draw/event/TextHandler.java
@@ -111,7 +111,7 @@ public class TextHandler implements Handler {
                 }
             } else {
                 view.updateSelectedItem();
-                view.moveSelection(view.getSelected());
+                view.refreshSelection();
             }
         }
     }

--- a/src/main/java/net/perspective/draw/event/TextHandler.java
+++ b/src/main/java/net/perspective/draw/event/TextHandler.java
@@ -91,14 +91,14 @@ public class TextHandler implements Handler {
             Text item = new Text(listener.getTempX(), listener.getTempY());
             item = textController.initializeItem(item);
             item.updateProperties(drawarea);
-            view.setNewItem(item);
+            // Append directly: setNewItem replaces the top item when a drawing is in progress,
+            // and the append reports the slot, so the selection needs no size arithmetic.
+            ItemId id = view.appendItemToCanvas(item);
             view.resetNewItem();
-            int i = view.getDrawings().size() - 1;
-            view.setSelected(i);
+            view.setSelected(id);
             view.setEditing(KeyHandlerType.TEXT);
-            view.setTextHighlight(i);
-        } else if (view.getSelected() != -1 && !listener.wasDragged()) {
-            DrawItem current = view.getDrawings().get(view.getSelected());
+            view.setTextHighlight(id);                // setSelected ran before edit mode was on
+        } else if (!listener.wasDragged() && view.getSelectedDrawItem() instanceof DrawItem current) {
             if (!current.contains(listener.getTempX(), listener.getTempY())) {
                 Editor editor = textController.getEditor();
                 if (current instanceof Text item) {
@@ -118,8 +118,8 @@ public class TextHandler implements Handler {
 
     @Override
     public void hoverEvent() {
-        if (view.getSelected() != -1) {
-            DrawItem item = view.getDrawings().get(view.getSelected());
+        DrawItem item = view.getSelectedDrawItem();
+        if (item != null) {
             if (item instanceof Text) {
                 context.setBehaviour(textItemBehaviourProvider.get());
                 context.hover(item);
@@ -133,8 +133,8 @@ public class TextHandler implements Handler {
     public void dragEvent() {
         if (view.isEditing()) {
             // Text isSelecting code here
-            if (view.getSelected() != -1) {
-                DrawItem item = view.getDrawings().get(view.getSelected());
+            DrawItem item = view.getSelectedDrawItem();
+            if (item != null) {
                 context.setBehaviour(textItemBehaviourProvider.get());
                 context.alter(item, 0, 0);
             }

--- a/src/main/java/net/perspective/draw/event/behaviours/BehaviourContext.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/BehaviourContext.java
@@ -27,6 +27,7 @@ import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.geom.DrawItem;
 import net.perspective.draw.util.CanvasPoint;
@@ -71,23 +72,23 @@ public class BehaviourContext {
 
     /**
      * Activate the strategy's select behaviour
-     * 
+     *
      * @param item  a {@link net.perspective.draw.geom.DrawItem}
-     * @param index  the index of the item in list of drawings
+     * @param id  the slot id of the item
      * @return item is selected
      */
-    public boolean select(DrawItem item, int index) {
-        return strategy.selectItem(this, item, index);
+    public boolean select(DrawItem item, ItemId id) {
+        return strategy.selectItem(this, item, id);
     }
 
     /**
      * Activate the strategy's edit behaviour
-     * 
+     *
      * @param item  a {@link net.perspective.draw.geom.DrawItem}
-     * @param index  the index of the item in list of drawings
+     * @param id  the slot id of the item
      */
-    public void edit(DrawItem item, int index) {
-        strategy.editItem(this, item, index);
+    public void edit(DrawItem item, ItemId id) {
+        strategy.editItem(this, item, id);
     }
 
     /**

--- a/src/main/java/net/perspective/draw/event/behaviours/FigureItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/FigureItemBehaviour.java
@@ -28,6 +28,7 @@ import javafx.scene.Cursor;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.enums.DrawingType;
 import net.perspective.draw.event.DrawAreaListener;
@@ -59,7 +60,7 @@ public class FigureItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         boolean found = false;
         int quad;
 
@@ -75,22 +76,22 @@ public class FigureItemBehaviour implements ItemBehaviours {
                     quad = R2.quadrant(vertex[1], centre);
                     switch (quad) {
                         case 0 -> {
-                            view.setSelected(index);
+                            view.setSelectedId(id);
                             context.setContainment(ContainsType.TR);
                             found = true;
                         }
                         case 1 -> {
-                            view.setSelected(index);
+                            view.setSelectedId(id);
                             context.setContainment(ContainsType.TL);
                             found = true;
                         }
                         case 2 -> {
-                            view.setSelected(index);
+                            view.setSelectedId(id);
                             context.setContainment(ContainsType.BL);
                             found = true;
                         }
                         case 3 -> {
-                            view.setSelected(index);
+                            view.setSelectedId(id);
                             context.setContainment(ContainsType.BR);
                             found = true;
                         }
@@ -109,22 +110,22 @@ public class FigureItemBehaviour implements ItemBehaviours {
                         quad = R2.quarter(edge[1], centre);
                         switch (quad) {
                             case 0 -> {
-                                view.setSelected(index);
+                                view.setSelectedId(id);
                                 context.setContainment(ContainsType.TT);
                                 found = true;
                             }
                             case 1 -> {
-                                view.setSelected(index);
+                                view.setSelectedId(id);
                                 context.setContainment(ContainsType.LL);
                                 found = true;
                             }
                             case 2 -> {
-                                view.setSelected(index);
+                                view.setSelectedId(id);
                                 context.setContainment(ContainsType.BB);
                                 found = true;
                             }
                             case 3 -> {
-                                view.setSelected(index);
+                                view.setSelectedId(id);
                                 context.setContainment(ContainsType.RR);
                                 found = true;
                             }
@@ -136,13 +137,13 @@ public class FigureItemBehaviour implements ItemBehaviours {
                 }
             }
             if (!found && item.contains(listener.getStartX(), listener.getStartY())) {
-                view.setSelected(index);
+                view.setSelectedId(id);
                 context.setContainment(ContainsType.SHAPE);
                 found = true;
             }
         } else if (item.contains(listener.getStartX(), listener.getStartY())) {
             // All other figures
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
@@ -150,7 +151,7 @@ public class FigureItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
         // not implemented
     }
 

--- a/src/main/java/net/perspective/draw/event/behaviours/GroupedItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/GroupedItemBehaviour.java
@@ -28,6 +28,7 @@ import javafx.scene.Cursor;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.event.DrawAreaListener;
 import net.perspective.draw.geom.DrawItem;
@@ -57,7 +58,7 @@ public class GroupedItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         boolean found = false;
         int quad;
 
@@ -68,22 +69,22 @@ public class GroupedItemBehaviour implements ItemBehaviours {
                 quad = R2.quadrant(vertex[1], centre);
                 switch (quad) {
                     case 0 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.TR);
                         found = true;
                     }
                     case 1 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.TL);
                         found = true;
                     }
                     case 2 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.BL);
                         found = true;
                     }
                     case 3 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.BR);
                         found = true;
                     }
@@ -96,7 +97,7 @@ public class GroupedItemBehaviour implements ItemBehaviours {
             context.setSgndArea(((Grouped) item).sgnd_area());
         }
         if (!found && item.contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
@@ -104,7 +105,7 @@ public class GroupedItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
         // not implemented
     }
 

--- a/src/main/java/net/perspective/draw/event/behaviours/ItemBehaviours.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/ItemBehaviours.java
@@ -23,18 +23,19 @@
  */
 package net.perspective.draw.event.behaviours;
 
+import net.perspective.draw.ItemId;
 import net.perspective.draw.geom.DrawItem;
 
 /**
- * 
+ *
  * @author ctipper
  */
 
 public interface ItemBehaviours {
 
-    boolean selectItem(BehaviourContext context, DrawItem item, int index);
+    boolean selectItem(BehaviourContext context, DrawItem item, ItemId id);
 
-    void editItem(BehaviourContext context, DrawItem item, int index);
+    void editItem(BehaviourContext context, DrawItem item, ItemId id);
 
     void hoverItem(BehaviourContext context, DrawItem item);
 

--- a/src/main/java/net/perspective/draw/event/behaviours/ItemBehaviours.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/ItemBehaviours.java
@@ -33,12 +33,41 @@ import net.perspective.draw.geom.DrawItem;
 
 public interface ItemBehaviours {
 
+    /**
+     * Select the item, setting the containment type on the context
+     *
+     * @param context  a {@link net.perspective.draw.event.behaviours.BehaviourContext}
+     * @param item  a {@link net.perspective.draw.geom.DrawItem}
+     * @param id  the slot id of the item
+     * @return item is selected
+     */
     boolean selectItem(BehaviourContext context, DrawItem item, ItemId id);
 
+    /**
+     * Enter the item's editing mode
+     *
+     * @param context  a {@link net.perspective.draw.event.behaviours.BehaviourContext}
+     * @param item  a {@link net.perspective.draw.geom.DrawItem}
+     * @param id  the slot id of the item
+     */
     void editItem(BehaviourContext context, DrawItem item, ItemId id);
 
+    /**
+     * Set the cursor for the pointer's position over the item
+     *
+     * @param context  a {@link net.perspective.draw.event.behaviours.BehaviourContext}
+     * @param item  a {@link net.perspective.draw.geom.DrawItem}
+     */
     void hoverItem(BehaviourContext context, DrawItem item);
 
+    /**
+     * Transform the item according to the containment type set by selection
+     *
+     * @param context  a {@link net.perspective.draw.event.behaviours.BehaviourContext}
+     * @param item  a {@link net.perspective.draw.geom.DrawItem}
+     * @param xinc  an x increment
+     * @param yinc  a y increment
+     */
     void alterItem(BehaviourContext context, DrawItem item, double xinc, double yinc);
 
 }

--- a/src/main/java/net/perspective/draw/event/behaviours/MapItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/MapItemBehaviour.java
@@ -26,6 +26,7 @@ package net.perspective.draw.event.behaviours;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.MapController;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.enums.HandlerType;
@@ -57,30 +58,30 @@ public class MapItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         boolean found = false;
         if (context.getRegion(item.getTop()[0]).
             contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.TL);
             found = true;
         } else if (context.getRegion(item.getDown()[0]).
             contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.BL);
             found = true;
         } else if (context.getRegion(item.getBottom()[0]).
             contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.BR);
             found = true;
         } else if (context.getRegion(item.getUp()[0]).
             contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.TR);
             found = true;
         } else if (item.contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
@@ -88,8 +89,8 @@ public class MapItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
-        view.setSelected(index);
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
+        view.setSelectedId(id);
         drawarea.changeHandlers(HandlerType.MAP);
         view.setEditing(KeyHandlerType.MAP);
         mapper.initMap();

--- a/src/main/java/net/perspective/draw/event/behaviours/PictureItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/PictureItemBehaviour.java
@@ -28,6 +28,7 @@ import javafx.scene.Cursor;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.event.DrawAreaListener;
 import net.perspective.draw.geom.DrawItem;
@@ -57,7 +58,7 @@ public class PictureItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         boolean found = false;
         int quad;
 
@@ -68,22 +69,22 @@ public class PictureItemBehaviour implements ItemBehaviours {
                 quad = R2.quadrant(vertex[1], centre);
                 switch (quad) {
                     case 0 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.TR);
                         found = true;
                     }
                     case 1 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.TL);
                         found = true;
                     }
                     case 2 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.BL);
                         found = true;
                     }
                     case 3 -> {
-                        view.setSelected(index);
+                        view.setSelectedId(id);
                         context.setContainment(ContainsType.BR);
                         found = true;
                     }
@@ -96,7 +97,7 @@ public class PictureItemBehaviour implements ItemBehaviours {
             context.setSgndArea(((Picture) item).sgnd_area());
         }
         if (!found && item.contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
@@ -104,7 +105,7 @@ public class PictureItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
         // not implemented
     }
 

--- a/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
@@ -132,7 +132,9 @@ public class RotateBehaviour  implements ItemBehaviours {
                 drawarea.rotateTo(item, theta);
             }
 
-            item.updateProperties(drawarea);
+            if (view.isSingleSelection()) {
+                item.updateProperties(drawarea);
+            }
             view.updateCanvasItem(selection, item);
             view.moveSelection(selection);
             listener.setStartX(listener.getTempX());

--- a/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
@@ -89,7 +89,7 @@ public class RotateBehaviour  implements ItemBehaviours {
     public void alterItem(BehaviourContext context, DrawItem item, double xinc, double yinc) {
         CanvasPoint A, B;
 
-        if (view.getSelected() != -1) {
+        if (view.hasSelection()) {
             int selection = view.getSelected();
             drawarea.getScene().setCursor(Cursor.CLOSED_HAND);
             CanvasPoint centre = item.rotationCentre();

--- a/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javafx.scene.Cursor;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.enums.ContainsType;
 import net.perspective.draw.event.DrawAreaListener;
 import net.perspective.draw.geom.DrawItem;
@@ -57,10 +58,10 @@ public class RotateBehaviour  implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         boolean found = false;
         if (item.getRotateBounds().contains(listener.getStartX(), listener.getStartY())) {
-            view.setSelected(index);
+            view.setSelectedId(id);
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
@@ -71,7 +72,7 @@ public class RotateBehaviour  implements ItemBehaviours {
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
         
     }
 

--- a/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/RotateBehaviour.java
@@ -65,8 +65,9 @@ public class RotateBehaviour  implements ItemBehaviours {
             context.setContainment(ContainsType.SHAPE);
             found = true;
         }
-        if (view.getSelected() != -1) {
-            omega = view.getDrawings().get(view.getSelected()).getAngle();
+        DrawItem selected = view.getSelectedDrawItem();
+        if (selected != null) {
+            omega = selected.getAngle();
         }
         return found;
     }

--- a/src/main/java/net/perspective/draw/event/behaviours/TextItemBehaviour.java
+++ b/src/main/java/net/perspective/draw/event/behaviours/TextItemBehaviour.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.TextController;
 import net.perspective.draw.enums.KeyHandlerType;
 import net.perspective.draw.event.DrawAreaListener;
@@ -64,7 +65,7 @@ public class TextItemBehaviour implements ItemBehaviours {
     }
 
     @Override
-    public boolean selectItem(BehaviourContext context, DrawItem item, int index) {
+    public boolean selectItem(BehaviourContext context, DrawItem item, ItemId id) {
         Editor editor = textControllerProvider.get().getEditor();
         Group layout = drawarea.getTextLayout(item);
 
@@ -74,22 +75,22 @@ public class TextItemBehaviour implements ItemBehaviours {
 
         editor.setCaretStart(caretIndex);
         editor.setCaretEnd(caretIndex);
-        view.setTextHighlight(index);
+        view.setTextHighlight(id);
         return true;
     }
 
     @Override
-    public void editItem(BehaviourContext context, DrawItem item, int index) {
+    public void editItem(BehaviourContext context, DrawItem item, ItemId id) {
         Group layout = drawarea.getTextLayout(item);
 
         // currently fix for vertical text is not known
         Point2D point = new Point2D(listener.getTempX() - item.getTop()[0].x, listener.getTempY() - item.getTop()[0].y);
         int caretIndex = hitTextLayout(layout, point);
 
-        view.resetSelected(index);
+        view.resetSelectedId(id);
         view.setEditing(KeyHandlerType.TEXT);
         textControllerProvider.get().editItem((Text) item, caretIndex);
-        view.setTextHighlight(index);
+        view.setTextHighlight(id);
     }
 
     @Override

--- a/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
@@ -26,6 +26,7 @@ package net.perspective.draw.event.keyboard;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
 import net.perspective.draw.MapController;
 import net.perspective.draw.enums.DrawingType;
 import net.perspective.draw.enums.HandlerType;
@@ -41,7 +42,9 @@ public class MapKeyHandler implements KeyHandler {
     private final CanvasView view;
     @Inject MapController mapper;
     @Inject KeyListener keylistener;
-    private int selection = -1;
+    /** Selection stashed across an Alt interlude. Held as an id: an index would rot if the
+     * document changed while the key was down. */
+    private ItemId selection;
     private DrawingType drawingtype;
     private HandlerType handlerType;
     private boolean isMapping = false;
@@ -72,7 +75,7 @@ public class MapKeyHandler implements KeyHandler {
                 if (!pressed) {
                     drawingtype = drawarea.getDrawType().orElse(null);
                     handlerType = drawarea.getHandlerType();
-                    selection = view.getSelected();
+                    selection = view.getSelectedId();
                     drawarea.setDrawType(null);
                     drawarea.changeHandlers(HandlerType.SELECTION);
                     isMapping = view.isMapping();

--- a/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
@@ -93,14 +93,18 @@ public class MapKeyHandler implements KeyHandler {
     public void keyReleased() {
         switch (keylistener.getKeyCode()) {
             case ALT, ALT_GRAPH -> {
-                drawarea.setDrawType(drawingtype);
-                drawarea.changeHandlers(handlerType);
-                drawarea.setMultiSelectEnabled(false);
-                view.setMapping(isMapping);
-                view.setSelected(selection);
-                mapper.initMap();
-                pressed = false;
-
+                // Only unwind an interlude this handler actually opened: a release can arrive
+                // with no matching press, when the handler was swapped while the key was held
+                // or the platform took the press for its menu bar.
+                if (pressed) {
+                    drawarea.setDrawType(drawingtype);
+                    drawarea.changeHandlers(handlerType);
+                    drawarea.setMultiSelectEnabled(false);
+                    view.setMapping(isMapping);
+                    view.setSelected(selection);
+                    mapper.initMap();
+                    pressed = false;
+                }
             }
             default -> {
             }

--- a/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/MapKeyHandler.java
@@ -61,7 +61,7 @@ public class MapKeyHandler implements KeyHandler {
 
     @Override
     public void keyPressed() {
-        if ((view.getSelected() != -1) && (view.isMapping())) {
+        if (view.hasSelection() && view.isMapping()) {
             switch (keylistener.getKeyCode()) {
                 case KP_UP, UP -> mapper.moveMap(0, -20);
                 case KP_DOWN, DOWN -> mapper.moveMap(0, 20);
@@ -109,7 +109,7 @@ public class MapKeyHandler implements KeyHandler {
 
     @Override
     public void keyTyped() {
-        if ((view.getSelected() != -1) && (view.isMapping())) {
+        if (view.hasSelection() && view.isMapping()) {
             String c = keylistener.getKeyChar();
             switch (c) {
                 case "+" -> mapper.zoomIn();

--- a/src/main/java/net/perspective/draw/event/keyboard/MoveKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/MoveKeyHandler.java
@@ -26,6 +26,8 @@ package net.perspective.draw.event.keyboard;
 import javax.inject.Inject;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
+import net.perspective.draw.ItemStore;
 import net.perspective.draw.enums.DrawingType;
 import net.perspective.draw.enums.HandlerType;
 import net.perspective.draw.geom.DrawItem;
@@ -39,6 +41,7 @@ public class MoveKeyHandler implements KeyHandler {
 
     private final DrawingArea drawarea;
     private final CanvasView view;
+    @Inject ItemStore store;
     @Inject KeyListener keylistener;
     private DrawingType drawingtype;
     private HandlerType handlertype;
@@ -59,8 +62,9 @@ public class MoveKeyHandler implements KeyHandler {
         /**
          * Keyboard movement semantics
          */
-        if ((view.getSelected() != -1) && !view.isEditing()) {
-            DrawItem item = view.getDrawings().get(view.getSelected());
+        ItemId id = view.getSelectedId();
+        DrawItem item = store.lookupId(id);
+        if (item != null && !view.isEditing()) {
             switch (keylistener.getKeyCode()) {
                 case KP_UP, UP -> {
                     if (!drawarea.isRotationMode()) {
@@ -94,8 +98,13 @@ public class MoveKeyHandler implements KeyHandler {
                 default -> {
                 }
             }
-            view.moveSelection(view.getSelected());
-            view.updateCanvasItem(view.getSelected(), item);
+            /*
+             * The snap and rotate cases above edit the item in place, so it has to be republished
+             * or the change never reaches the canvas. After DELETE the slot is gone and both calls
+             * no-op on the stale id, which is what stops the item being resurrected.
+             */
+            view.updateCanvasItem(id, item);
+            view.refreshSelection();
         }
         /**
          * Keyboard paste operation semantics
@@ -159,7 +168,7 @@ public class MoveKeyHandler implements KeyHandler {
             if (!HandlerType.ROTATION.equals(drawarea.getHandlerType())) {
                 drawarea.setRotationMode(false);
             }
-            view.moveSelection(view.getSelected());
+            view.refreshSelection();
         }
     }
 

--- a/src/main/java/net/perspective/draw/event/keyboard/MoveKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/MoveKeyHandler.java
@@ -155,10 +155,20 @@ public class MoveKeyHandler implements KeyHandler {
         boolean wasRotating = drawarea.isRotationMode();
         switch (keylistener.getKeyCode()) {
             case ALT, ALT_GRAPH -> {
-                drawarea.setDrawType(drawingtype);
-                drawarea.changeHandlers(handlertype);
-                drawarea.setMultiSelectEnabled(false);
-                pressed = false;
+                // Only unwind an interlude this handler actually opened: a release can arrive
+                // with no matching press, when the handler was swapped while the key was held
+                // or the platform took the press for its menu bar.
+                if (pressed) {
+                    /*
+                     * Restoring the tool drops the selection with it: every changeHandlers() case
+                     * but SELECTION clears it, and a group marquee'd under Alt is not meant to
+                     * outlive the interlude that made it.
+                     */
+                    drawarea.setDrawType(drawingtype);
+                    drawarea.changeHandlers(handlertype);
+                    drawarea.setMultiSelectEnabled(false);
+                    pressed = false;
+                }
             }
             default -> {
             }

--- a/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
@@ -50,9 +50,15 @@ public class TextKeyHandler implements KeyHandler {
     @Inject ItemStore store;
     @Inject KeyListener keylistener;
     @Inject Provider<TextController> textControllerProvider;
-    /** Selection stashed across an Alt interlude. Held as an id: an index would rot if the
-     * document changed while the key was down. */
-    private ItemId selection;
+    /**
+     * Selection stashed across an Alt interlude, restored on release.
+     *
+     * <p>Written only when Alt goes down and read only when it comes up. Kept apart from the
+     * per-event selection, which the pressed and typed handlers read into a local: Alt
+     * auto-repeats, so those handlers run again while it is held, and sharing one field let a
+     * selection made during the interlude overwrite the very thing being stashed for restore.</p>
+     */
+    private ItemId stashedSelection;
     private boolean selectToLeft = false;
     private DrawingType drawingtype;
     private HandlerType handlerType;
@@ -82,8 +88,7 @@ public class TextKeyHandler implements KeyHandler {
     @Override
     public void keyPressed() {
         Editor editor = textControllerProvider.get().getEditor();
-        selection = view.getSelectedId();
-        DrawItem drawitem = store.lookupId(selection);
+        DrawItem drawitem = view.getSelectedDrawItem();
         if (drawitem != null && view.isEditing()) {
             if (drawitem instanceof Text item) {
                 // edit
@@ -318,7 +323,7 @@ public class TextKeyHandler implements KeyHandler {
                 if (!pressed) {
                     drawingtype = drawarea.getDrawType().orElse(null);
                     handlerType = drawarea.getHandlerType();
-                    selection = view.getSelectedId();
+                    stashedSelection = view.getSelectedId();
                     drawarea.setDrawType(null);
                     drawarea.changeHandlers(HandlerType.SELECTION);
                     isEditing = view.isEditing();
@@ -343,7 +348,7 @@ public class TextKeyHandler implements KeyHandler {
                 drawarea.changeHandlers(handlerType);
                 drawarea.setMultiSelectEnabled(false);
                 view.setEditing(isEditing);
-                view.setSelected(selection);
+                view.setSelected(stashedSelection);
                 pressed = false;
             }
             default -> {
@@ -357,8 +362,7 @@ public class TextKeyHandler implements KeyHandler {
     @Override
     public void keyTyped() {
         Editor editor = textControllerProvider.get().getEditor();
-        selection = view.getSelectedId();
-        DrawItem drawitem = store.lookupId(selection);
+        DrawItem drawitem = view.getSelectedDrawItem();
         if (drawitem != null && view.isEditing()) {
             if (drawitem instanceof Text item) {
                 String keyChar = keylistener.getKeyChar();

--- a/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
@@ -344,12 +344,17 @@ public class TextKeyHandler implements KeyHandler {
     public void keyReleased() {
         switch (keylistener.getKeyCode()) {
             case ALT, ALT_GRAPH -> {
-                drawarea.setDrawType(drawingtype);
-                drawarea.changeHandlers(handlerType);
-                drawarea.setMultiSelectEnabled(false);
-                view.setEditing(isEditing);
-                view.setSelected(stashedSelection);
-                pressed = false;
+                // Only unwind an interlude this handler actually opened: a release can arrive
+                // with no matching press, when the handler was swapped while the key was held
+                // or the platform took the press for its menu bar.
+                if (pressed) {
+                    drawarea.setDrawType(drawingtype);
+                    drawarea.changeHandlers(handlerType);
+                    drawarea.setMultiSelectEnabled(false);
+                    view.setEditing(isEditing);
+                    view.setSelected(stashedSelection);
+                    pressed = false;
+                }
             }
             default -> {
             }

--- a/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
+++ b/src/main/java/net/perspective/draw/event/keyboard/TextKeyHandler.java
@@ -27,6 +27,8 @@ import javax.inject.Provider;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
+import net.perspective.draw.ItemId;
+import net.perspective.draw.ItemStore;
 import net.perspective.draw.TextController;
 import net.perspective.draw.enums.DrawingType;
 import net.perspective.draw.enums.HandlerType;
@@ -45,9 +47,12 @@ public class TextKeyHandler implements KeyHandler {
     private final DrawingArea drawarea;
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject KeyListener keylistener;
     @Inject Provider<TextController> textControllerProvider;
-    private int selection = -1;
+    /** Selection stashed across an Alt interlude. Held as an id: an index would rot if the
+     * document changed while the key was down. */
+    private ItemId selection;
     private boolean selectToLeft = false;
     private DrawingType drawingtype;
     private HandlerType handlerType;
@@ -77,9 +82,9 @@ public class TextKeyHandler implements KeyHandler {
     @Override
     public void keyPressed() {
         Editor editor = textControllerProvider.get().getEditor();
-        selection = view.getSelected();
-        if ((selection != -1) && (view.isEditing())) {
-            DrawItem drawitem = view.getDrawings().get(selection);
+        selection = view.getSelectedId();
+        DrawItem drawitem = store.lookupId(selection);
+        if (drawitem != null && view.isEditing()) {
             if (drawitem instanceof Text item) {
                 // edit
                 int textlength = editor.getLength();
@@ -305,7 +310,7 @@ public class TextKeyHandler implements KeyHandler {
                 }
                 item.setDimensions();
                 view.updateSelectedItem();
-                view.moveSelection(view.getSelected());
+                view.refreshSelection();
             }
         }
         switch (keylistener.getKeyCode()) {
@@ -313,7 +318,7 @@ public class TextKeyHandler implements KeyHandler {
                 if (!pressed) {
                     drawingtype = drawarea.getDrawType().orElse(null);
                     handlerType = drawarea.getHandlerType();
-                    selection = view.getSelected();
+                    selection = view.getSelectedId();
                     drawarea.setDrawType(null);
                     drawarea.changeHandlers(HandlerType.SELECTION);
                     isEditing = view.isEditing();
@@ -352,9 +357,9 @@ public class TextKeyHandler implements KeyHandler {
     @Override
     public void keyTyped() {
         Editor editor = textControllerProvider.get().getEditor();
-        selection = view.getSelected();
-        if ((selection != -1) && (view.isEditing())) {
-            DrawItem drawitem = view.getDrawings().get(selection);
+        selection = view.getSelectedId();
+        DrawItem drawitem = store.lookupId(selection);
+        if (drawitem != null && view.isEditing()) {
             if (drawitem instanceof Text item) {
                 String keyChar = keylistener.getKeyChar();
                 /**
@@ -378,7 +383,7 @@ public class TextKeyHandler implements KeyHandler {
                     }
                     item.setDimensions();
                     view.updateSelectedItem();
-                    view.moveSelection(view.getSelected());
+                    view.refreshSelection();
                 }
             }
         }

--- a/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
+++ b/src/main/java/net/perspective/draw/workers/ImageLoadWorker.java
@@ -41,6 +41,7 @@ import net.perspective.draw.CanvasView;
 import net.perspective.draw.DrawingArea;
 import net.perspective.draw.ImageItem;
 import net.perspective.draw.ShareUtils;
+import net.perspective.draw.geom.DrawItem;
 import net.perspective.draw.geom.Picture;
 import net.perspective.draw.util.FileUtils;
 import net.perspective.draw.util.Messages;
@@ -89,6 +90,12 @@ public class ImageLoadWorker extends Task<Object> {
         logger.info("Reading images complete.");
         Platform.runLater(() -> {
             if (!images.isEmpty()) {
+                /*
+                 * Each image is registered before the Picture that references it by index, and the
+                 * Pictures are published together at the end: appending them one at a time rebuilds
+                 * the store snapshot per image, which is O(n²) across a multi-image import.
+                 */
+                List<DrawItem> pictures = new ArrayList<>(images.size());
                 for (int i = 0; i < images.size(); i++) {
                     Image image = images.get(i);
                     Picture picture = pictureProvider.get();
@@ -102,10 +109,11 @@ public class ImageLoadWorker extends Task<Object> {
                     logger.trace("Image relative scale: {}", scale);
                     picture.setImage(index, width, height);
                     picture.setScale(scale);
-                    view.setNewItem(picture);
-                    view.resetNewItem();
+                    pictures.add(picture);
                     shift = shift + 10.0;
                 }
+                view.appendItemsToCanvas(pictures);
+                view.resetNewItem();
             }
             share.setImageFiles(null);
         });

--- a/src/main/java/net/perspective/draw/workers/PDFWorker.java
+++ b/src/main/java/net/perspective/draw/workers/PDFWorker.java
@@ -35,6 +35,8 @@ import javafx.concurrent.Task;
 import javax.inject.Inject;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
+import net.perspective.draw.ItemStore;
+import net.perspective.draw.ItemStore.SaveState;
 import net.perspective.draw.ShareUtils;
 import net.perspective.draw.util.CanvasPoint;
 import net.perspective.draw.util.Messages;
@@ -56,9 +58,11 @@ public class PDFWorker extends Task<Object> {
 
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject ShareUtils share;
     private File file;
     private double margin;
+    private SaveState state;
 
     private static final Logger logger = LoggerFactory.getLogger(SVGWorker.class.getName());
 
@@ -71,6 +75,18 @@ public class PDFWorker extends Task<Object> {
 
     public void setFile(File file) {
         this.file = file;
+    }
+
+    /**
+     * Capture the document to be exported. Call on the FX thread, before submitting the task.
+     *
+     * <p>Fixes one item list for both the bounds calculation and the render — reading the store
+     * separately for each lets the document change in between, sizing the page for one set of
+     * items and drawing another. {@link ItemStore#saveState()} also records the revision, so an
+     * edit landing mid-export can be reported; see {@link Serialiser#make()}.</p>
+     */
+    public void captureDocument() {
+        state = store.saveState();
     }
 
     public void setMargin(double margin) {
@@ -108,8 +124,8 @@ public class PDFWorker extends Task<Object> {
         }
 
         public void make() {
-            // Calculate drawing bounds
-            final CanvasPoint[] bounds = view.getBounds();
+            // Calculate drawing bounds — same capture the render below uses
+            final CanvasPoint[] bounds = view.getBounds(state.items());
             CanvasPoint start = bounds[0].shifted(-margin, -margin).floor();
             CanvasPoint end = bounds[1].shifted(margin, margin);
 
@@ -137,7 +153,7 @@ public class PDFWorker extends Task<Object> {
                 g2.setDeviceDPI(72.0f);
 
                 // Ask to render into the PDF Graphics2D implementation.
-                view.getDrawings().stream().forEach((item) -> {
+                state.items().stream().forEach((item) -> {
                     item.draw(g2);
                 });
 
@@ -146,6 +162,11 @@ public class PDFWorker extends Task<Object> {
                 logger.warn(e.getMessage());
             } catch (ConfigurationException e) {
                 logger.error(null, e);
+            }
+
+            if (store.revision() != state.revision()) {
+                logger.warn("Document changed during PDF export ({} -> {}); the file may not match "
+                    + "either state.", state.revision(), store.revision());
             }
         }
 

--- a/src/main/java/net/perspective/draw/workers/PNGWorker.java
+++ b/src/main/java/net/perspective/draw/workers/PNGWorker.java
@@ -35,6 +35,8 @@ import javax.imageio.ImageIO;
 import javax.inject.Inject;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
+import net.perspective.draw.ItemStore;
+import net.perspective.draw.ItemStore.SaveState;
 import net.perspective.draw.ShareUtils;
 import net.perspective.draw.util.CanvasPoint;
 import net.perspective.draw.util.Messages;
@@ -50,10 +52,12 @@ public class PNGWorker extends Task<Object> {
 
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject ShareUtils share;
     protected File file;
     private boolean opacity;
     private double margin;
+    private SaveState state;
 
     private static final Logger logger = LoggerFactory.getLogger(PNGWorker.class.getName());
 
@@ -67,6 +71,18 @@ public class PNGWorker extends Task<Object> {
 
     public void setFile(File file) {
         this.file = file;
+    }
+
+    /**
+     * Capture the document to be exported. Call on the FX thread, before submitting the task.
+     *
+     * <p>Fixes one item list for both the bounds calculation and the render — reading the store
+     * separately for each lets the document change in between, sizing the image for one set of
+     * items and drawing another. {@link ItemStore#saveState()} also records the revision, so an
+     * edit landing mid-export can be reported; see {@link Serialiser#make()}.</p>
+     */
+    public void captureDocument() {
+        state = store.saveState();
     }
 
     public void setOpacity(boolean opacity) {
@@ -117,8 +133,8 @@ public class PNGWorker extends Task<Object> {
         }
 
         public void make() {
-            // Calculate draw area
-            final CanvasPoint[] bounds = view.getBounds();
+            // Calculate draw area — same capture the render below uses
+            final CanvasPoint[] bounds = view.getBounds(state.items());
             CanvasPoint start = bounds[0].shifted(-margin, -margin).grow(scale).floor();
             CanvasPoint end = bounds[1].shifted(margin, margin).grow(scale);
 
@@ -139,7 +155,7 @@ public class PNGWorker extends Task<Object> {
             g2.transform(java.awt.geom.AffineTransform.getTranslateInstance(0, 0));
             g2.transform(java.awt.geom.AffineTransform.getScaleInstance(scale, scale));
             // Render image
-            view.getDrawings().stream().forEach((item) -> {
+            state.items().stream().forEach((item) -> {
                 item.draw(g2);
             });
             g2.dispose();
@@ -155,6 +171,11 @@ public class PNGWorker extends Task<Object> {
                 logger.warn("Failed to write PNG.");
             } catch (IOException e) {
                 logger.warn(e.getMessage());
+            }
+
+            if (store.revision() != state.revision()) {
+                logger.warn("Document changed during PNG export ({} -> {}); the file may not match "
+                    + "either state.", state.revision(), store.revision());
             }
         }
     }

--- a/src/main/java/net/perspective/draw/workers/ReadInFunnel.java
+++ b/src/main/java/net/perspective/draw/workers/ReadInFunnel.java
@@ -102,15 +102,17 @@ public class ReadInFunnel extends Task<Object> {
         Platform.runLater(() -> {
             if (success) {
                 drawarea.prepareDrawing();
-                // Rebuild the image list in saved order so each item's imageIndex
-                // resolves to the correct bitmap. Must run after prepareDrawing(),
-                // which clears the image list via clearView().
-                view.getImageItems().addAll(pictures);
+                /*
+                 * Rebuild each item before any of them are published: checkDrawings swaps in
+                 * DI-constructed replacements and recomputes geometry, which is work that must not
+                 * be visible half-done. loadItemsToCanvas then installs the images and the items
+                 * together, in that order, as one publication.
+                 */
+                List<DrawItem> prepared = new ArrayList<>(drawings.size());
                 for (var drawitem : drawings) {
-                    var item = checkDrawings(drawitem);
-                    view.setNewItem(item);
-                    view.resetNewItem();
+                    prepared.add(checkDrawings(drawitem));
                 }
+                view.loadItemsToCanvas(prepared, pictures);
             }
         });
         CompletableFuture.runAsync(() -> {

--- a/src/main/java/net/perspective/draw/workers/SVGWorker.java
+++ b/src/main/java/net/perspective/draw/workers/SVGWorker.java
@@ -32,6 +32,8 @@ import org.jfree.svg.SVGGraphics2D;
 import org.jfree.svg.SVGHints;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
+import net.perspective.draw.ItemStore;
+import net.perspective.draw.ItemStore.SaveState;
 import net.perspective.draw.ShareUtils;
 import net.perspective.draw.util.CanvasPoint;
 import net.perspective.draw.util.Messages;
@@ -47,9 +49,11 @@ public class SVGWorker extends Task<Object> {
 
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject ShareUtils share;
     private File file;
     private double margin;
+    private SaveState state;
 
     private static final Logger logger = LoggerFactory.getLogger(SVGWorker.class.getName());
 
@@ -62,6 +66,18 @@ public class SVGWorker extends Task<Object> {
 
     public void setFile(File file) {
         this.file = file;
+    }
+
+    /**
+     * Capture the document to be exported. Call on the FX thread, before submitting the task.
+     *
+     * <p>Fixes one item list for both the bounds calculation and the render — reading the store
+     * separately for each lets the document change in between, sizing the canvas for one set of
+     * items and drawing another. {@link ItemStore#saveState()} also records the revision, so an
+     * edit landing mid-export can be reported; see {@link Serialiser#make()}.</p>
+     */
+    public void captureDocument() {
+        state = store.saveState();
     }
 
     public void setMargin(double margin) {
@@ -99,8 +115,8 @@ public class SVGWorker extends Task<Object> {
         }
 
         public void make() {
-            // Calculate drawing bounds
-            final CanvasPoint[] bounds = view.getBounds();
+            // Calculate drawing bounds — same capture the render below uses
+            final CanvasPoint[] bounds = view.getBounds(state.items());
             CanvasPoint start = bounds[0].shifted(-margin, -margin).floor();
             CanvasPoint end = bounds[1].shifted(margin, margin);
 
@@ -120,7 +136,7 @@ public class SVGWorker extends Task<Object> {
             g2.translate(-start.x, -start.y);
 
             // Ask to render into the SVG Graphics2D implementation.
-            view.getDrawings().stream().forEach((item) -> {
+            state.items().stream().forEach((item) -> {
                 item.draw(g2);
             });
 
@@ -151,6 +167,11 @@ public class SVGWorker extends Task<Object> {
 
             // Clean up
             g2.dispose();
+
+            if (store.revision() != state.revision()) {
+                logger.warn("Document changed during SVG export ({} -> {}); the file may not match "
+                    + "either state.", state.revision(), store.revision());
+            }
         }
     }
 

--- a/src/main/java/net/perspective/draw/workers/WriteOutStreamer.java
+++ b/src/main/java/net/perspective/draw/workers/WriteOutStreamer.java
@@ -25,6 +25,7 @@ package net.perspective.draw.workers;
 
 import java.awt.image.BufferedImage;
 import java.io.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.zip.ZipEntry;
@@ -39,6 +40,8 @@ import javafx.embed.swing.SwingFXUtils;
 import net.perspective.draw.ApplicationController;
 import net.perspective.draw.CanvasView;
 import net.perspective.draw.ImageItem;
+import net.perspective.draw.ItemStore;
+import net.perspective.draw.ItemStore.SaveState;
 import net.perspective.draw.ShareUtils;
 import net.perspective.draw.geom.DrawItem;
 import net.perspective.draw.serialise.ArrowLinePersistenceDelegate;
@@ -61,8 +64,11 @@ public class WriteOutStreamer extends Task<Object> {
 
     private final CanvasView view;
     private final ApplicationController controller;
+    @Inject ItemStore store;
     @Inject ShareUtils share;
     private File file;
+    private SaveState state;
+    private List<ImageItem> pictures;
 
     private static final Logger logger = LoggerFactory.getLogger(WriteOutStreamer.class.getName());
 
@@ -74,6 +80,20 @@ public class WriteOutStreamer extends Task<Object> {
 
     public void setFile(File file) {
         this.file = file;
+    }
+
+    /**
+     * Capture the document to be written. Call on the FX thread, before submitting the task.
+     *
+     * <p>{@link #call()} runs on a worker thread, and the image list is plain FX-thread state — a
+     * paste landing mid-write would have the writer iterating a list under mutation. The item list
+     * is safe to read off-thread, being a published snapshot, but the <em>items</em> are live and
+     * the EDT may still edit one in place. {@link ItemStore#saveState()} records the revision so
+     * that can at least be detected; see {@link #make()}.</p>
+     */
+    public void captureDocument() {
+        state = store.saveState();
+        pictures = new ArrayList<>(view.getImageItems());
     }
 
     @Override
@@ -133,7 +153,6 @@ public class WriteOutStreamer extends Task<Object> {
             ZipEntry entry = new ZipEntry("content/pictures.xml");
             zos.putNextEntry(entry);
 
-            List<ImageItem> pictures = view.getImageItems();
             encoder = new net.perspective.draw.serialise.XMLEncoder(zos);
             encoder.setPersistenceDelegate(java.time.Instant.class,
                 new InstantPersistenceDelegate());
@@ -164,7 +183,7 @@ public class WriteOutStreamer extends Task<Object> {
             entry = new ZipEntry("content/canvas.xml");
             zos.putNextEntry(entry);
 
-            List<DrawItem> drawings = view.getDrawings();
+            List<DrawItem> drawings = state.items();
             encoder = new net.perspective.draw.serialise.XMLEncoder(zos);
             encoder.setPersistenceDelegate(java.awt.BasicStroke.class,
                 new BasicStrokePersistenceDelegate());
@@ -188,6 +207,17 @@ public class WriteOutStreamer extends Task<Object> {
             encoder.finished();
             zos.closeEntry();
             updateProgress(3L, 3L);
+
+            /*
+             * The capture fixed which items exist and in what order, but not the items themselves:
+             * the EDT may have edited one in place while its fields were being read, giving an
+             * item that serialized half-old and half-new. A moved revision is the only evidence of
+             * that, and only holds because every EDT mutation republishes through replaceItem.
+             */
+            if (store.revision() != state.revision()) {
+                logger.warn("Document changed during save ({} -> {}); the written file may not "
+                    + "match either state.", state.revision(), store.revision());
+            }
         }
     }
 


### PR DESCRIPTION
Replaces index-based addressing of canvas items with a stable per-slot identity, so selection, grouping and z-order operations survive the document changing underneath them.

## Motivation

The canvas held items in an `ObservableList<DrawItem>` and referred to them by position. An index is only true until the next mutation, so any code holding one across a change was addressing whatever had since moved into that slot. That is not a bug in one place — it is a property of the model, and it produced faults of the same shape in several unrelated areas.

`ItemStore` gives each slot an `ItemId` that stays valid across replacement and reordering. `replaceItem` rebinds a slot's existing id; `move` repositions without minting a new one. Selection, multi-selection and group membership are therefore safe to hold.

Indices have not gone away — they are what the serialized format and any positional API use. They are now resolved from a single snapshot at that boundary, and nowhere further out.

## Defects fixed that predate this work

Each verified against `969c849`.

1. **Selection did not survive z-order changes.** All four of `sendBackwards`/`bringForwards`/`sendToBack`/`bringToFront` removed and re-added the item without updating `selectionIndex`, so the selection silently moved to whatever took that slot.
2. **Alt-stash clobber in `TextKeyHandler`.** One `int selection` field served as both per-event scratch and the Alt stash. Alt auto-repeats, so the scratch write overwrote the stash and release restored the wrong item — reported in testing as a `ClassCastException`.
3. **Unguarded cast in the caret path.** `setTextHighlight` passed whatever it found to `highlightText`, which casts to `Text`. Reachable whenever edit mode and the selection disagreed.
4. **Text-Paste context menu action had no guard.** `getDrawings().get(-1)` on an empty selection. Cut and Copy were guarded; Paste was not.
5. **In-place text edits never repainted.** Cut, paste and rich-text format called `setDimensions()` and then only redrew the anchors; the item's node was rebuilt solely by the list listener, which those paths never triggered.
6. **Guides excluded the wrong item.** `drawings.indexOf(drawing) != getSelected()` matches by value, so with two equal items it skipped the first match rather than the selected one.
7. **Exporters read the document twice, from a worker thread.** PDF, SVG and PNG each called `getBounds()` and then `getDrawings()` against the live list — an unsynchronised cross-thread read, and a page sized from one state but drawn from another.
8. **Save read live mutable state off-thread.** `getImageItems()` returned the live `ArrayList` to the writer's `Task` thread.
9. **`setNewItem` replaced the top item when a drawing was in progress.** Callers meaning "append" — map creation, text creation, image import — would clobber the in-progress item.

## Structure

- **`ItemStore`** — id-keyed document model. Mutations publish an immutable `Snapshot`; readers never lock. Four background readers (the writer and three exporters) consume snapshots off-thread.
- **`FxSnapshotBinder`** — reconciles the scene graph against the newest snapshot, diffing by id so a change to one item updates one node rather than rebuilding the list. Coalesces bursts onto the FX thread.
- **`ItemId`** — opaque per-session slot identity. Not serialized, not sent anywhere; identity is a store concern, not part of the object model.

## Compatibility

The serialisation format is unchanged — same entries, same objects, same persistence delegates. Save/reopen round trips were tested with images and grouped items.

## Testing

Manual, throughout. Drawing and dragging, grouping and ungrouping, text editing, arrow-key nudge and Alt-rotate, Alt-hold selection restore in text and map modes, multi-image import, SVG paste from clipboard and file, all four export formats checked for correct bounds, and save/reopen round trips.

No automated tests were added. The load, save and export paths are the ones where a regression would be silent until a file is reopened.

## Points worth a reviewer's attention

- `itemBase()` in `CanvasView` locates the item nodes by counting leading chrome from the scene graph rather than from the `isGridVisible()`/`hasGuides()` flags. It rests on one invariant, documented there: only the grid and guides insert at index 0, everything else appends. Anything new that inserts at the front must carry a chrome id.
- `drainDirty()` must be called before reading the snapshot, never after. The reasoning is in its javadoc; reversing the order can strand a write.
- `ItemStore`'s javadoc describes a sync thread supplying deserialized replacements. That is inherited from the sibling project and is **not** true here — this project has a single writer on the FX thread and background readers only. The guards are cheap and were kept deliberately, but the rationale in those comments overstates the hazard.
